### PR TITLE
Stop capping how many answers may be outstanding

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ sequenceDiagram
 
     Note over C: heartbeat, then a per second countdown
     C->>S: GET / at two seconds out, to warm the connection
-    Note over C: the warm up finishes before the window, it spends a token too
+    Note over C: the warm up is sent and not waited for, it spends a token too
 
     Note over C,S: the burst, one request per 1.3s
     loop until every course lands or you stop it
@@ -175,9 +175,29 @@ timeout. A scheduler that waits for each answer before sending the next request
 is paced by the portal's latency rather than by the edge limit, which is the
 one thing it was built to respect.
 
-So the token spacing governs when a request leaves, and up to `-inflight`
-requests may be waiting for an answer at once. The portal has a concurrency
-guard of its own, `TOO_MANY_REQUESTS`, so the default is a modest 3.
+So the token spacing alone governs when a request leaves, and answers land
+whenever they land. There is no cap on outstanding answers by default, because
+the scheduler is already bounded twice over: a course with a request in flight
+is never picked again, so there is at most one per course, and no request
+outlives the 10 second timeout. The ceiling is the smaller of your list length
+and `timeout / gap`, about eight at the defaults.
+
+A cap below that ceiling throttles *sending* rather than answering. With answers
+taking `T` seconds and a cap of `C`, a request can only leave every `T / C`
+seconds, so a cap of 3 against the 5 second answers measured inside the window
+paces you at 1.7s, slower than the edge actually allows. Modelled on the
+2026-09-08 shape, ten courses with three second answers and two requests that
+hang to the timeout, the last course on the list gets its first attempt at:
+
+| | last course's first attempt |
+| --- | --- |
+| `-inflight 3` | 15.2s |
+| uncapped, the default | 11.7s |
+
+11.7s is exactly ten tokens at 1.3s, which is the floor. `-inflight` remains as
+an escape hatch for `TOO_MANY_REQUESTS`, the portal's own concurrency guard,
+which has never been seen live. `-inflight 1` restores the old serial
+behaviour.
 
 ## Decision 3: every course before any second attempt
 
@@ -278,7 +298,7 @@ curl https://erfnzdeh.github.io/my.edu.sharif.edu-sniper/api/courses.json
 | `-catalogue` | Path or URL of `courses.json`. |
 | `-transcript` | Transcript path. Defaults to `snipe-<timestamp>.log`. |
 | `-gap` | Minimum spacing between two requests. Defaults to `1.3s`. |
-| `-inflight` | How many requests may wait for an answer at once. Defaults to `3`. |
+| `-inflight` | Cap on requests waiting for an answer. Defaults to `0`, no cap. |
 | `-version` | Print the version, platform and Go version, then exit. |
 
 Exit codes: `0` when everything landed, `1` when something is still

--- a/cmd/sniper/main.go
+++ b/cmd/sniper/main.go
@@ -77,13 +77,21 @@ var (
 	// which is a bad trade now that a rejection is cheap but not free.
 	// See docs/reference/rate-limits.md.
 	globalGap = 1300 * time.Millisecond
-	// maxInflight is how many requests may be waiting for an answer at once.
-	// Inside the window a single answer took two to five seconds, and one
-	// that timed out held the whole queue for ten, so a strictly serial
-	// scheduler spends the contested seconds waiting rather than asking.
-	// The portal has a concurrency guard of its own, TOO_MANY_REQUESTS, so
-	// this stays small.
-	maxInflight = 3
+	// maxInflight caps how many requests may be waiting for an answer at
+	// once. Zero, the default, means no cap, because the scheduler is
+	// already bounded twice over: a course with a request in flight is never
+	// picked again, so there is at most one per course, and no request can
+	// outlive httpTimeout. The real ceiling is the smaller of the list
+	// length and httpTimeout/globalGap, which is about eight at the
+	// defaults.
+	//
+	// A cap below that ceiling throttles sending rather than answering. At
+	// the five second answers measured inside the window, a cap of three
+	// lets a request leave only every 1.7s, which is slower than the gap the
+	// edge actually allows, so the cap and not the limiter sets the pace.
+	// It stays as an escape hatch for TOO_MANY_REQUESTS, the portal's own
+	// concurrency guard, which has never been seen live.
+	maxInflight = 0
 )
 
 // Result codes, taken from the portal frontend bundle.
@@ -231,7 +239,7 @@ func run() int {
 		fCatalogue  = flag.String("catalogue", "", "path or URL of courses.json, overrides the default lookup")
 		fTranscript = flag.String("transcript", "", "transcript file path, defaults to snipe-<timestamp>.log")
 		fGap        = flag.Duration("gap", globalGap, "minimum spacing between two requests, the edge allows one per second")
-		fInflight   = flag.Int("inflight", maxInflight, "how many requests may wait for an answer at once")
+		fInflight   = flag.Int("inflight", maxInflight, "cap on requests waiting for an answer at once, 0 for no cap")
 		fVersion    = flag.Bool("version", false, "print the version and exit")
 	)
 	flag.Parse()
@@ -241,8 +249,8 @@ func run() int {
 		globalGap = 100 * time.Millisecond
 	}
 	maxInflight = *fInflight
-	if maxInflight < 1 {
-		maxInflight = 1
+	if maxInflight < 0 {
+		maxInflight = 0
 	}
 
 	if *fVersion {
@@ -282,11 +290,20 @@ func run() int {
 	ui.tr = tr
 	ui.info("transcript %s", tr.path)
 	tr.write("BUILD    %s %s/%s %s", buildVersion(), runtime.GOOS, runtime.GOARCH, runtime.Version())
-	tr.write("PACING   gap=%s cooldown=%s inflight=%d rateLimitBackoff=%s parkedBackoff=%s timeout=%s",
-		globalGap, courseCooldown, maxInflight, rateLimitBackoff, parkedBackoff, httpTimeout)
+	tr.write("PACING   gap=%s cooldown=%s inflight=%s rateLimitBackoff=%s parkedBackoff=%s timeout=%s",
+		globalGap, courseCooldown, inflightNote(len(courses)), rateLimitBackoff, parkedBackoff, httpTimeout)
 
+	// The default transport keeps two idle connections per host, so with
+	// answers overlapping, the third concurrent request onwards would find an
+	// empty pool and pay a fresh TLS handshake, measured at about 650ms, every
+	// time it went out. Keep one warm connection per course instead. If the
+	// portal speaks HTTP/2 this is moot, since one connection carries them
+	// all: the transcript's proto= field says which happened.
+	pool := http.DefaultTransport.(*http.Transport).Clone()
+	pool.MaxIdleConns = 4 * len(courses)
+	pool.MaxIdleConnsPerHost = 2 * len(courses)
 	cl := &client{
-		http:  &http.Client{Timeout: httpTimeout},
+		http:  &http.Client{Timeout: httpTimeout, Transport: pool},
 		token: token,
 		tr:    tr,
 	}
@@ -368,7 +385,7 @@ func fireWindow(parent context.Context, ui *ui, cl *client, courses []*course) b
 		// the client made rather than from now.
 		nextSend = cl.called().Add(globalGap)
 	)
-	slots := make(chan struct{}, maxInflight)
+	slots := make(chan struct{}, inflightCap(len(courses)))
 	wake := make(chan struct{}, 1)
 	notify := func() {
 		select {
@@ -470,6 +487,23 @@ func fireWindow(parent context.Context, ui *ui, cl *client, courses []*course) b
 
 	wg.Wait()
 	return authBad
+}
+
+// inflightCap is how many answers may be outstanding. A course with a request
+// in flight is never picked again, so the length of the list is a hard ceiling
+// and an uncapped run simply uses it.
+func inflightCap(courses int) int {
+	if maxInflight <= 0 || maxInflight > courses {
+		return courses
+	}
+	return maxInflight
+}
+
+func inflightNote(courses int) string {
+	if maxInflight <= 0 {
+		return fmt.Sprintf("uncapped, ceiling %d", inflightCap(courses))
+	}
+	return strconv.Itoa(maxInflight)
 }
 
 // choose returns the course that should get the next token, and the soonest
@@ -1237,7 +1271,7 @@ func confirm(ui *ui, courses []*course, s *clockSync, target, fireAt time.Time, 
 	}
 	ui.plain("  window opens  %s", target.Format("2006-01-02 15:04:05.000"))
 	ui.plain("  firing at     %s (in %s)", fireAt.Format("15:04:05.000"), time.Until(fireAt).Truncate(time.Millisecond))
-	ui.plain("  pacing        one request every %s, %s per course, up to %d in flight", globalGap, courseCooldown, maxInflight)
+	ui.plain("  pacing        one request every %s, %s per course, up to %d in flight", globalGap, courseCooldown, inflightCap(len(courses)))
 	if yes {
 		return true
 	}

--- a/cmd/sniper/sniper_test.go
+++ b/cmd/sniper/sniper_test.go
@@ -139,7 +139,7 @@ func TestFireWindowLandsEveryCourseWhileAnswersAreSlow(t *testing.T) {
 
 	defer swap(&regEndpoint, srv.URL)()
 	defer swap(&globalGap, 40*time.Millisecond)()
-	defer swap(&maxInflight, 3)()
+	defer swap(&maxInflight, 3)() // pinned, this test is about the cap holding
 
 	courses := mkCourses("a", "b", "c", "d", "e", "f")
 	cl := &client{http: &http.Client{Timeout: 5 * time.Second}}
@@ -158,13 +158,14 @@ func TestFireWindowLandsEveryCourseWhileAnswersAreSlow(t *testing.T) {
 			t.Errorf("%s never landed", c.id)
 		}
 	}
-	// Serially this is six courses times a 300ms answer. Overlapping them has
-	// to beat that clearly, or the concurrency is not doing anything.
+	// The structural check is the real one: requests have to overlap at all.
 	if p.maxAtOnce < 2 {
 		t.Errorf("never had more than %d request in flight, requests are not overlapping", p.maxAtOnce)
 	}
-	if took > 1500*time.Millisecond {
-		t.Errorf("took %s, want well under the 1.8s a serial run would need", took)
+	// The timing check is bounded by what a serial run would cost rather than
+	// by a fixed number, so a loaded machine cannot fail it on its own.
+	if serial := time.Duration(len(courses)) * p.delay; took >= serial {
+		t.Errorf("took %s, a serial run would have been %s, so nothing was gained", took, serial)
 	}
 	if p.maxAtOnce > maxInflight {
 		t.Errorf("%d requests were in flight at once, the cap is %d", p.maxAtOnce, maxInflight)
@@ -174,6 +175,76 @@ func TestFireWindowLandsEveryCourseWhileAnswersAreSlow(t *testing.T) {
 
 // TestFireWindowKeepsTheGapWhenAnswersAreInstant guards the case the edge
 // actually rejects: two requests less than a token apart.
+// TestFireWindowUncappedUsesTheWholeList is the default shape: no cap, so the
+// only ceiling is one request per course. It has to overlap more than the old
+// fixed cap of three would have allowed.
+func TestFireWindowUncappedUsesTheWholeList(t *testing.T) {
+	p := &portal{delay: 700 * time.Millisecond, registered: map[string]bool{}}
+	srv := httptest.NewServer(p)
+	defer srv.Close()
+
+	defer swap(&regEndpoint, srv.URL)()
+	defer swap(&globalGap, 40*time.Millisecond)()
+	defer swap(&maxInflight, 0)() // no cap
+
+	courses := mkCourses("a", "b", "c", "d", "e", "f")
+	cl := &client{http: &http.Client{Timeout: 5 * time.Second}}
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+	defer cancel()
+
+	fireWindow(ctx, newTestUI(), cl, courses)
+
+	for _, c := range courses {
+		if !c.done {
+			t.Errorf("%s never landed", c.id)
+		}
+	}
+	if p.maxAtOnce <= 3 {
+		t.Errorf("peaked at %d in flight, an uncapped run with 700ms answers should beat the old cap of 3", p.maxAtOnce)
+	}
+	if p.maxAtOnce > len(courses) {
+		t.Errorf("%d in flight for %d courses, a course must never have two requests out at once", p.maxAtOnce, len(courses))
+	}
+	assertSpacing(t, p.arrivals, globalGap)
+}
+
+// TestFireWindowInflightOneIsSerial checks the escape hatch still works, since
+// it is what someone would reach for if TOO_MANY_REQUESTS ever showed up.
+func TestFireWindowInflightOneIsSerial(t *testing.T) {
+	p := &portal{delay: 200 * time.Millisecond, registered: map[string]bool{}}
+	srv := httptest.NewServer(p)
+	defer srv.Close()
+
+	defer swap(&regEndpoint, srv.URL)()
+	defer swap(&globalGap, 20*time.Millisecond)()
+	defer swap(&maxInflight, 1)()
+
+	courses := mkCourses("a", "b", "c")
+	cl := &client{http: &http.Client{Timeout: 5 * time.Second}}
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+	defer cancel()
+
+	fireWindow(ctx, newTestUI(), cl, courses)
+	if p.maxAtOnce != 1 {
+		t.Errorf("peaked at %d in flight, -inflight 1 must stay serial", p.maxAtOnce)
+	}
+}
+
+func TestInflightCapNeverExceedsTheCourseCount(t *testing.T) {
+	defer swap(&maxInflight, 0)()
+	if got := inflightCap(6); got != 6 {
+		t.Errorf("uncapped with 6 courses = %d, want 6", got)
+	}
+	swap(&maxInflight, 99)
+	if got := inflightCap(6); got != 6 {
+		t.Errorf("cap of 99 with 6 courses = %d, want 6", got)
+	}
+	swap(&maxInflight, 2)
+	if got := inflightCap(6); got != 2 {
+		t.Errorf("cap of 2 with 6 courses = %d, want 2", got)
+	}
+}
+
 func TestFireWindowKeepsTheGapWhenAnswersAreInstant(t *testing.T) {
 	p := &portal{delay: 0, registered: map[string]bool{}}
 	srv := httptest.NewServer(p)

--- a/docs/reference/rate-limits.md
+++ b/docs/reference/rate-limits.md
@@ -158,9 +158,11 @@ expensive. The frontend ships user facing strings for all of it:
 
 `BLOCKED` is keyed on the **student ID**, so unlike the edge limiter it follows
 you across networks and cannot be escaped by reconnecting. `TOO_MANY_REQUESTS`
-is a concurrency guard, which is why the scheduler still sends on a single
-global token and only lets a few answers be outstanding at once. Neither code
-has been seen live. If one shows up, lower `-inflight`.
+is a concurrency guard. The scheduler still sends on a single global token, so
+it never exceeds one request per gap however many answers are outstanding, and
+the number outstanding is capped anyway at one per course. Neither code has been
+seen live. If one shows up, `-inflight` sets a hard cap and `-inflight 1`
+restores serial behaviour.
 
 ---
 


### PR DESCRIPTION
## What this changes

`-inflight` now defaults to `0`, meaning no cap, and the connection pool is
sized to the course list.

## Why

The cap of 3 was chosen defensively against `TOO_MANY_REQUESTS`. It turns out
to sit below the point where a cap starts throttling *sending* rather than
answering: with answers taking `T` and a cap of `C`, a request can only leave
every `T / C` seconds. Answers inside the 2026-09-08 window ran 2.1s to 5.1s,
so at the slow end a cap of 3 paced requests at 1.7s, wider than the 1.3s gap
the edge allows. The cap was setting the pace, not the limiter.

Removing it is safe because the scheduler is bounded twice over already: a
course with a request in flight is never picked again, so there is at most one
per course, and no request outlives the 10s timeout. The ceiling is the smaller
of the list length and `timeout / gap`, about 8 at the defaults.

## How it was verified

- `gofmt`, `go vet`, `go build`, `go test -race -count=2`, run against an
  isolated export of this exact tree.
- New tests: uncapped overlaps beyond the old cap of 3 and never exceeds one
  request per course, `-inflight 1` stays strictly serial, and `inflightCap`
  clamps to the list length. The existing spacing assertion still holds, so the
  token gap is unchanged by any of this.
- The timing assertion in the pre-existing concurrency test is now bounded by
  what a serial run would cost rather than by a fixed number, so a loaded
  machine cannot fail it on its own.
- Measured on a stand-in portal shaped like that window, ten courses with 3s
  answers and two requests hanging to the timeout.
- Not exercised against a live registration window.

## If it touches timing

It does.

| | last course's first attempt |
| --- | --- |
| `-inflight 3` | 15.2s |
| uncapped, the new default | 11.7s |

11.7s is exactly ten tokens at 1.3s, the floor, which is the point: the edge
limiter is now the only thing pacing the run. `globalGap` is unchanged at
1.3s, and the send rate is still one request per gap however many answers are
outstanding.

`TOO_MANY_REQUESTS` and `BLOCKED` have never been seen live, and `BLOCKED` is
keyed on the student ID, so it would follow you across networks. That is the
risk being taken here. `-inflight` is the escape hatch if either shows up in a
transcript, and the new `proto=` field in the log will also say whether the
portal speaks HTTP/2, in which case one connection carries everything and the
pool sizing is moot.

## Checklist

- [x] `gofmt -l ./cmd ./tools` prints nothing
- [x] `go vet ./...` and `go build ./...` are clean
- [x] No new dependency, and `cmd/sniper` is still standard library only
- [x] No token, transcript or student identifier in the diff
- [x] README or `docs/reference` updated if behaviour changed

Note: `cmd/sniper/main.go` is being edited concurrently in another session
(`timingResults`, `holdResults`). This branch was built from a temporary index
against `HEAD` so it contains none of that work and did not disturb that
working tree.
