### PR TITLE
Close what a second read of the window transcripts found

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ Log in at [my.edu.sharif.edu](https://my.edu.sharif.edu) shortly before your
 window, open the browser network tab, and copy the `Authorization` request
 header from any API call. Sessions last roughly an hour.
 
+Then leave the portal alone until the run is over. The edge limiter counts
+every request from your IP, so a click in the browser during the window costs
+the sniper a `429`, and one run on 2026-09-08 took a rejection that its own
+traffic cannot explain.
+
 Every run prints its version in the banner and the transcript, and
 `sniper -version` reports it on its own. Quote it in any bug report.
 
@@ -227,13 +232,19 @@ toward the window. Given a probe sent at `t0`, answered at `t1`, with the
 server reporting `S` and the window at `R`:
 
 ```
-fire = t1 + (R - S) + roundTrip + 100ms
+fire = t1 + (R - S) + 100ms
 ```
 
-The margin is biased late deliberately. Arriving early is rejected **and**
-burns that course's five second cooldown, so a request 100ms early costs about
-five seconds. A request 100ms late costs 100ms. The client prints this
-derivation with your actual numbers before it commits to a fire time.
+That is later than it looks. The server stamps `S` as it answers, so by `t1`
+its clock is already half a round trip past `S`, and the request spends the
+other half on the way in: it reaches the server a full network round trip
+after the window opens, plus the 100ms. The margin is biased late
+deliberately, because arriving early is rejected and puts that course on its
+five second cooldown, while arriving late costs only the delay. The formula
+used to add the probe's round trip too, and since the probe runs on a cold
+connection that included a TLS handshake: one run on 2026-09-08 fired 1.2s
+after the window for nothing. The client prints the derivation with your
+actual numbers before it commits to a fire time.
 
 ## Decision 5: units come from the catalogue
 

--- a/README.md
+++ b/README.md
@@ -140,11 +140,15 @@ sequenceDiagram
 
 ---
 
-## Decision 1: pace at one request per second
+## Decision 1: pace at about one request per second
 
-This is the whole game. The edge allows one request per second, applied per
-client, and rejects the excess with a real `429` rather than queueing it. A
-parallel burst therefore throws most of its requests away. Full measurements in
+This is the whole game. The edge rejects requests that follow too closely on
+the previous one from the same IP with a real `429` rather than queueing them,
+so a parallel burst throws most of its requests away. How close is too close
+is not known exactly. Every measurement so far fits a limit of about one
+request per second counted when the request arrives, but none of them proves
+it, and one rejection on 2026-09-08 came five seconds after anything the
+sniper had sent. Full measurements, and what they do not settle, are in
 [docs/reference/rate-limits.md](docs/reference/rate-limits.md).
 
 So the scheduler holds a single global token, released every 1.3 seconds, and
@@ -168,9 +172,13 @@ between attempts at the same course, and the global rule is one request per
 second overall. With five or more courses the global rule already satisfies
 the per course one, and below that the per course cooldown binds.
 
-The gap is 1.3 seconds rather than 1.1 because round trip jitter regularly
-lands two requests less than a second apart at the edge. At 1.1s about one
-request in seven came back `429`, which buys nothing.
+The gap is 1.3 seconds rather than 1.1 because at 1.1s about one request in
+seven came back `429` on 2026-09-07, and at 1.3s none did. That is a small
+sample and a working default rather than a measured threshold, which is why
+`-gap` exists. The token is counted from the moment a request is written to
+the connection, not from when the scheduler decided to send it, because a
+request that has to open a connection first reaches the edge several hundred
+milliseconds later than one on a warm connection.
 
 ## Decision 2: sending does not wait for the answer
 

--- a/cmd/sniper/main.go
+++ b/cmd/sniper/main.go
@@ -1,8 +1,9 @@
 // Command sniper registers courses on my.edu.sharif.edu the moment the
 // registration window opens.
 //
-// The portal's edge allows exactly one request per second with no burst, so
-// the scheduler spends one request token at a time. Every course gets its
+// The portal's edge rejects a request that follows the previous one too
+// closely, and everything measured so far fits about one per second with no
+// burst, so the scheduler spends one request token at a time. Every course gets its
 // first attempt before any course gets its second, and within the same
 // attempt count list order is priority order. Answers take seconds to come
 // back, so a few requests may be waiting at once: the token spacing is what
@@ -75,10 +76,11 @@ const (
 // Pacing, overridable from the command line because the right values depend
 // on the link and both cost something when they are wrong.
 var (
-	// globalGap is the minimum spacing between two requests. The edge allows
-	// one per second and counts every request to the host, including the warm
-	// up. A 1.1s gap loses about one request in seven to round trip jitter,
-	// which is a bad trade now that a rejection is cheap but not free.
+	// globalGap is the minimum spacing between two requests. The edge looks
+	// like about one per second, and counts every request to the host,
+	// including the warm up. A 1.1s gap lost about one request in seven to
+	// round trip jitter, which is a bad trade now that a rejection is cheap
+	// but not free. A working default from small samples, hence the flag.
 	// See docs/reference/rate-limits.md.
 	globalGap = 1300 * time.Millisecond
 	// maxInflight caps how many requests may be waiting for an answer at
@@ -208,6 +210,7 @@ type course struct {
 	next     time.Time // not eligible to be retried before this
 	pending  bool      // a request is in flight right now
 	parked   bool      // last result cannot change on a retry
+	early    int       // timing rejections so far, only the first is free
 	done     bool
 	landed   time.Time
 	last     string // most recent result seen
@@ -266,7 +269,7 @@ func run() int {
 		fYes        = flag.Bool("y", false, "skip the confirmation prompt, requires -token and -courses")
 		fCatalogue  = flag.String("catalogue", "", "path or URL of courses.json, overrides the default lookup")
 		fTranscript = flag.String("transcript", "", "transcript file path, defaults to snipe-<timestamp>.log")
-		fGap        = flag.Duration("gap", globalGap, "minimum spacing between two requests, the edge allows one per second")
+		fGap        = flag.Duration("gap", globalGap, "minimum spacing between two requests, the edge allows about one per second")
 		fInflight   = flag.Int("inflight", maxInflight, "cap on requests waiting for an answer at once, 0 for no cap")
 		fVersion    = flag.Bool("version", false, "print the version and exit")
 	)
@@ -324,9 +327,10 @@ func run() int {
 	// The default transport keeps two idle connections per host, so with
 	// answers overlapping, the third concurrent request onwards would find an
 	// empty pool and pay a fresh TLS handshake, measured at about 650ms, every
-	// time it went out. Keep one warm connection per course instead. If the
-	// portal speaks HTTP/2 this is moot, since one connection carries them
-	// all: the transcript's proto= field says which happened.
+	// time it went out. Keep one warm connection per course instead. The
+	// portal negotiates HTTP/2, checked on 2026-09-08, so one connection
+	// carries them all and this only matters on a fallback to HTTP/1.1: the
+	// transcript's proto= field says which happened.
 	pool := http.DefaultTransport.(*http.Transport).Clone()
 	pool.MaxIdleConns = 4 * len(courses)
 	pool.MaxIdleConnsPerHost = 2 * len(courses)
@@ -704,12 +708,20 @@ func applyCode(ui *ui, c *course, attempt int, res string, rtt time.Duration) {
 	note := fmt.Sprintf("retry at %s", c.next.Format("15:04:05.000"))
 	k := kindBad
 	if why, timing := timingResults[res]; timing {
-		// The backend refused to look at the course, so this is not a verdict
-		// on it. It keeps its rank rather than falling behind every course
-		// tried after it, which matters most for the first course on the list
-		// when the opening request lands a moment early.
-		ui.attempt(c, attempt, res, why+", keeps its place", rtt, kindWarn)
-		return
+		c.early++
+		if c.early == 1 {
+			// The backend refused to look at the course, so this is not a
+			// verdict on it. It keeps its rank rather than falling behind
+			// every course tried after it, which matters most for the first
+			// course on the list when the opening request lands a moment
+			// early. Only the first one is free: a course the portal keeps
+			// refusing on timing grounds while the others get real verdicts
+			// would otherwise sit at judged 0 and outrank all of them for
+			// the rest of the run.
+			ui.attempt(c, attempt, res, why+", keeps its place", rtt, kindWarn)
+			return
+		}
+		note = why + ", " + note
 	}
 	c.judged++
 	if why, queued := queuedResults[res]; queued {

--- a/cmd/sniper/main.go
+++ b/cmd/sniper/main.go
@@ -52,6 +52,10 @@ const (
 	// freeze costs far more than the rejection did: on 2026-09-08 two 429s
 	// cost fourteen seconds of the most contested part of the window.
 	rateLimitBackoff = 2 * time.Second
+	// How long to hold every request after the portal reports BLOCKED. Its
+	// own text says minutes, and the block follows the student id rather than
+	// the connection, so there is nothing to gain by probing sooner.
+	blockedBackoff = 30 * time.Second
 	// How long to hold back a course whose result cannot change on a retry.
 	// It is still retried, because the operator may drop the course it
 	// clashes with, but it must not crowd out a course that can still land.
@@ -136,6 +140,30 @@ var permanentFailures = map[string]string{
 var queuedResults = map[string]string{
 	"REPEATED_REQUEST": "the portal already has this exact job queued",
 	"ALREADY_IN_QUEUE": "a job for this course is already queued",
+}
+
+// timingResults mean the backend refused to look at the course at all, so
+// they are not verdicts on it and do not count against it in the ordering.
+var timingResults = map[string]string{
+	"NO_REGISTRATION_TIME":    "registration is not open",
+	"REGISTRATION_TIME_LIMIT": "not your registration slot",
+	"NOT_LOGIN_TIME":          "not your registration slot",
+	"LOGIN_TIME_RESTRICTION":  "not your login window",
+	"EDU_TIME":                "the portal is only live 08:00 to 12:00",
+	"CLOSED_INTERVAL":         "the portal is closed at this hour",
+}
+
+// holdResults are the portal pushing back on the client as a whole rather
+// than judging a course, so they hold the shared token the way a 429 does.
+// None has been seen live. BLOCKED says "try again in a few minutes", and it
+// is keyed on the student id, so hammering through it can only prolong it.
+var holdResults = map[string]struct {
+	why  string
+	hold time.Duration
+}{
+	"TOO_MANY_REQUESTS": {"too many requests outstanding, lower -inflight if this repeats", rateLimitBackoff},
+	"PLEASE_WAIT":       {"the portal's upstream is struggling", rateLimitBackoff},
+	"BLOCKED":           {"your student id is restricted for excess requests", blockedBackoff},
 }
 
 type catalogueEntry struct {
@@ -396,6 +424,12 @@ func fireWindow(parent context.Context, ui *ui, cl *client, courses []*course) b
 
 	for ctx.Err() == nil {
 		mu.Lock()
+		// The client records when each request was actually written, which
+		// is later than the scheduler's send time on a cold connection, and
+		// the warm up writes a request the scheduler never sent at all.
+		if ns := cl.called().Add(globalGap); ns.After(nextSend) {
+			nextSend = ns
+		}
 		finished, wait := allDone(courses), time.Until(nextSend)
 		mu.Unlock()
 		if finished {
@@ -464,8 +498,18 @@ func fireWindow(parent context.Context, ui *ui, cl *client, courses []*course) b
 				authBad = true
 				ui.fatal("token rejected or expired, log in again and rerun")
 				cancel()
+			case errors.As(err, &str) && holdResults[str.code].hold > 0:
+				// The portal is pushing back on the client as a whole, not on
+				// this course, so hold the shared token and let the course
+				// keep its place, exactly as for a 429.
+				h := holdResults[str.code]
+				c.last = str.code
+				c.next = sent
+				if back := time.Now().Add(h.hold); back.After(nextSend) {
+					nextSend = back
+				}
+				ui.attempt(c, attempt, str.code, fmt.Sprintf("%s, next token in %s", h.why, h.hold), rtt, kindWarn)
 			case errors.As(err, &str):
-				c.judged++
 				applyCode(ui, c, attempt, str.code, rtt)
 			case err != nil:
 				// A request that gave up client side may still have been
@@ -476,7 +520,6 @@ func fireWindow(parent context.Context, ui *ui, cl *client, courses []*course) b
 				c.last = "error"
 				ui.attempt(c, attempt, "REQUEST FAILED", err.Error()+" (it may still have been carried out)", rtt, kindWarn)
 			default:
-				c.judged++
 				applyJobs(ui, courses, c, attempt, resp, rtt)
 				ui.setRemaining(resp.RemainingActions)
 			}
@@ -611,16 +654,22 @@ func orDash(s string) string {
 // harvests successes for any other course. jobs is newest first and
 // accumulates across the whole session, so the first match is the latest.
 func applyJobs(ui *ui, courses []*course, pick *course, attempt int, resp *regResponse, rtt time.Duration) {
+	// The newest job per course, judged or not. Skipping an unjudged job
+	// would fall through to an older one: on 2026-09-08 that read a pre
+	// window NO_REGISTRATION_TIME as the verdict on a course whose real job
+	// was still queued. Had the stale result been a permanent failure the
+	// course would have been parked for nothing.
 	seen := map[string]string{}
 	for _, j := range resp.Jobs {
-		if _, ok := seen[j.CourseID]; !ok && j.Result != "" {
+		if _, ok := seen[j.CourseID]; !ok {
 			seen[j.CourseID] = j.Result
 		}
 	}
 
-	if res, ok := seen[pick.id]; ok {
+	if res, ok := seen[pick.id]; ok && res != "" {
 		applyCode(ui, pick, attempt, res, rtt)
-	} else {
+	} else if !pick.done {
+		pick.judged++
 		pick.last = "QUEUED"
 		ui.attempt(pick, attempt, "QUEUED", "server has not judged it yet", rtt, kindWarn)
 	}
@@ -654,6 +703,15 @@ func applyCode(ui *ui, c *course, attempt int, res string, rtt time.Duration) {
 	c.last = res
 	note := fmt.Sprintf("retry at %s", c.next.Format("15:04:05.000"))
 	k := kindBad
+	if why, timing := timingResults[res]; timing {
+		// The backend refused to look at the course, so this is not a verdict
+		// on it. It keeps its rank rather than falling behind every course
+		// tried after it, which matters most for the first course on the list
+		// when the opening request lands a moment early.
+		ui.attempt(c, attempt, res, why+", keeps its place", rtt, kindWarn)
+		return
+	}
+	c.judged++
 	if why, queued := queuedResults[res]; queued {
 		note = why + ", waiting for its verdict instead of resending"
 		k = kindWarn
@@ -738,13 +796,14 @@ type client struct {
 	lastCall time.Time
 }
 
-// stringResult is a bare quoted string body, like
+// stringResult is a result code that arrived without a jobs array: either a
+// bare quoted string body, like
 //
 //	"REPEATED_REQUEST 40111099930004-11add"
 //
-// which is what the portal answers when it declines to queue the job at all.
-// The body carries no jobs array, so there is nothing to harvest from it and
-// the only way to learn the verdict is a later response.
+// which is what the portal answers when it declines to queue the job at all,
+// or the error field of an object. There is nothing to harvest from either,
+// and the only way to learn a queued job's verdict is a later response.
 type stringResult struct {
 	code   string
 	detail string
@@ -832,7 +891,9 @@ func (c *client) post(body regRequest) (*regResponse, time.Duration, error) {
 		return nil, rtt, errAuth
 	}
 	if out.Error != "" {
-		return nil, rtt, fmt.Errorf("%s", out.Error)
+		// An error field is a result code too, BLOCKED or NO_REMAINED_ACTION
+		// for instance, so it takes the same path as a bare string body.
+		return nil, rtt, &stringResult{code: out.Error}
 	}
 	return &out, rtt, nil
 }
@@ -860,18 +921,21 @@ func (c *client) do(req *http.Request, seq int) (*http.Response, []byte, time.Du
 		TLSHandshakeStart: func() { tlsAt = time.Now() },
 		TLSHandshakeDone:  func(tls.ConnectionState, error) { handshake = time.Since(tlsAt) },
 		// More than one write means net/http replayed the request on a fresh
-		// connection, which for an add would queue the job twice.
-		WroteRequest:         func(httptrace.WroteRequestInfo) { writes++ },
+		// connection, which for an add would queue the job twice. The write
+		// is also the moment the edge starts counting, so it is what the
+		// token is measured from.
+		WroteRequest: func(httptrace.WroteRequestInfo) {
+			writes++
+			c.mu.Lock()
+			c.lastCall = time.Now()
+			c.mu.Unlock()
+		},
 		GotFirstResponseByte: func() { ttfb = time.Since(start) },
 	}))
 
 	start = time.Now()
 	res, err := c.http.Do(req)
 	rtt := time.Since(start)
-
-	c.mu.Lock()
-	c.lastCall = time.Now()
-	c.mu.Unlock()
 
 	if err != nil {
 		c.tr.write("ERROR    #%d after %s: %v", seq, rtt.Truncate(time.Millisecond), err)
@@ -931,7 +995,13 @@ func clip(raw []byte, n int) string {
 // warmUp opens a connection shortly before the window so the first real
 // request does not pay a TLS handshake, which measured about 650ms. The GET
 // spends a rate limit token like any other request to the host, so it has to
-// finish a full gap before the window rather than inside it.
+// go out a full gap before the window rather than inside it.
+//
+// It does not wait for the answer. The token is spent when the request is
+// written, and a GET that is slow to come back must not hold the window: the
+// portal speaks HTTP/2, so the connection carries the first POST while the GET
+// is still outstanding, and if the connection never came up the first POST
+// dials one, which is all it would have done without a warm up.
 func (c *client) warmUp(ui *ui, fireAt time.Time) {
 	if since := time.Since(c.called()); since < warmupSkipIfNewerThan {
 		ui.info("warm up  skipped, connection pooled %s ago", since.Truncate(time.Second))
@@ -949,15 +1019,23 @@ func (c *client) warmUp(ui *ui, fireAt time.Time) {
 	c.tr.write("WARMUP   #%d GET %s/ at %s, %s before the window",
 		seq, portalOrigin, time.Now().Format("15:04:05.000"), time.Until(fireAt).Truncate(time.Millisecond))
 	start := time.Now()
-	if _, _, _, err := c.do(req, seq); err != nil {
-		ui.warn("warm up failed: %v", err)
-		return
-	}
-	left := time.Until(fireAt).Truncate(time.Millisecond)
-	ui.info("warm up  connection opened in %dms, %s before the window", time.Since(start).Milliseconds(), left)
-	if left < globalGap {
-		ui.warn("warm up  it ate into the first token, the opening request may be rejected")
-	}
+	// Count the token from now, in case the request is never written. The
+	// trace moves it to the actual write once that happens.
+	c.mu.Lock()
+	c.lastCall = start
+	c.mu.Unlock()
+	go func() {
+		if _, _, _, err := c.do(req, seq); err != nil {
+			ui.warn("warm up failed: %v, the first request will open its own connection", err)
+			return
+		}
+		took := time.Since(start).Milliseconds()
+		if left := time.Until(fireAt); left > 0 {
+			ui.info("warm up  connection opened in %dms, %s before the window", took, left.Truncate(time.Millisecond))
+		} else {
+			ui.warn("warm up  answered in %dms, %s after the window opened", took, (-left).Truncate(time.Millisecond))
+		}
+	}()
 }
 
 // ---------------------------------------------------------------- clock sync
@@ -997,11 +1075,19 @@ func (c *client) syncClock(co *course) (*clockSync, error) {
 	return s, nil
 }
 
-// fireTime keeps the formula the original script has always used. The margin
-// is deliberately biased late: arriving early is rejected and costs a full
-// cooldown, while arriving late costs only the delay itself.
+// fireTime is when the first request leaves. The server stamps its clock as
+// it answers, so at recv the server is already half a round trip past that
+// stamp, and the request spends the other half on the way in: sending at
+// recv + (window - server) lands a whole network round trip after the window
+// opens. The 100ms on top keeps it late through clock granularity and any
+// asymmetry, because arriving early is rejected while arriving late costs
+// only the delay itself.
+//
+// The formula used to add the probe's round trip as well, and the probe runs
+// on a cold connection, so that included a TLS handshake: one run on
+// 2026-09-08 fired 1.2s after the window for nothing.
 func (s *clockSync) fireTime(target time.Time) time.Time {
-	delay := target.Sub(s.server) + s.rtt + 100*time.Millisecond
+	delay := target.Sub(s.server) + 100*time.Millisecond
 	return s.recv.Add(delay)
 }
 
@@ -1509,9 +1595,11 @@ func (u *ui) showClockSync(s *clockSync) {
 func (u *ui) showFireTime(s *clockSync, target, fireAt time.Time) {
 	gap := target.Sub(s.server)
 	u.plain("")
-	u.plain("  fire = received + (window - serverClock) + roundTrip + 100ms")
-	u.plain("       = %s + %s + %s + 100ms",
-		s.recv.Format("15:04:05.000"), gap.Truncate(time.Millisecond), s.rtt.Truncate(time.Millisecond))
+	u.plain("  fire = received + (window - serverClock) + 100ms")
+	u.plain("       = %s + %s + 100ms",
+		s.recv.Format("15:04:05.000"), gap.Truncate(time.Millisecond))
+	u.plain("  %s", u.paint(cDim, fmt.Sprintf("the request lands a network round trip after that, about %s here",
+		s.rtt.Truncate(time.Millisecond))))
 	u.plain("       = %s", u.paint(cBold, fireAt.Format("15:04:05.000")))
 	u.plain("  %s", u.paint(cDim, "the margin is biased late on purpose: arriving early is rejected"))
 	u.plain("  %s", u.paint(cDim, "and costs a full cooldown, arriving late costs only the delay"))

--- a/cmd/sniper/sniper_test.go
+++ b/cmd/sniper/sniper_test.go
@@ -377,6 +377,37 @@ func TestApplyCodeTimingRejectionKeepsThePlace(t *testing.T) {
 	}
 }
 
+// TestTimingRejectionIsOnlyFreeOnce: a partial window, where the portal keeps
+// refusing one course on timing grounds while the others get real verdicts.
+// After its free first rejection the refused course has to count like any
+// other, or it sits at judged 0 and takes the token ahead of every course that
+// can still land, every time it comes off cooldown, for the rest of the run.
+func TestTimingRejectionIsOnlyFreeOnce(t *testing.T) {
+	courses := mkCourses("40760-1", "40634-1")
+	refused, judged := courses[0], courses[1]
+	now := time.Now()
+
+	applyCode(newTestUI(), refused, 1, "REGISTRATION_TIME_LIMIT", 0)
+	applyCode(newTestUI(), judged, 1, "CAPACITY_EXCEEDED", 0)
+	if pick, _ := choose(courses, now); pick != refused {
+		t.Fatalf("after one timing rejection pick = %s, want the refused course to keep its place", pick.id)
+	}
+
+	applyCode(newTestUI(), refused, 2, "REGISTRATION_TIME_LIMIT", 0)
+	if refused.judged != 1 {
+		t.Fatalf("judged = %d after a second timing rejection, want 1", refused.judged)
+	}
+	if refused.parked || refused.done {
+		t.Fatalf("parked=%t done=%t, a timing code is neither permanent nor a success", refused.parked, refused.done)
+	}
+	// Both are now judged once, so list order decides again, and a third
+	// rejection puts the refused course behind the one with a real verdict.
+	applyCode(newTestUI(), refused, 3, "REGISTRATION_TIME_LIMIT", 0)
+	if pick, _ := choose(courses, now); pick != judged {
+		t.Fatalf("after three timing rejections pick = %s, want the course with a real verdict", pick.id)
+	}
+}
+
 func TestPostTurnsAnErrorFieldIntoAResult(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, `{"error":"TOO_MANY_REQUESTS"}`)

--- a/cmd/sniper/sniper_test.go
+++ b/cmd/sniper/sniper_test.go
@@ -310,6 +310,118 @@ func TestPostReportsRateLimiting(t *testing.T) {
 	}
 }
 
+// TestApplyJobsReadsTheNewestJobEvenBeforeItIsJudged pins the run A shape of
+// 2026-09-08: the course's own job is still queued, and an older job for the
+// same course carries a stale verdict. The stale one must not be read.
+func TestApplyJobsReadsTheNewestJobEvenBeforeItIsJudged(t *testing.T) {
+	courses := mkCourses("37514-2", "40416-1")
+	pick := courses[0]
+	pick.next = time.Now().Add(courseCooldown)
+	resp := &regResponse{Jobs: []job{
+		{CourseID: "37514-2", Result: ""},              // this attempt, not judged yet
+		{CourseID: "37514-2", Result: "CLASS_OVERLAP"}, // an earlier attempt
+		{CourseID: "40416-1", Result: resultOK},
+	}}
+	applyJobs(newTestUI(), courses, pick, 1, resp, 0)
+
+	if pick.last != "QUEUED" {
+		t.Fatalf("last = %q, want QUEUED, the stale verdict was read instead", pick.last)
+	}
+	if pick.parked {
+		t.Fatal("a stale CLASS_OVERLAP parked a course whose real job is still queued")
+	}
+	if pick.judged != 1 {
+		t.Fatalf("judged = %d, want 1, the backend did see the request", pick.judged)
+	}
+	if !courses[1].done {
+		t.Fatal("an OK for another course was not harvested")
+	}
+}
+
+// TestFireTimeDoesNotAddTheProbeRoundTrip: the probe runs on a cold
+// connection, so its round trip includes a TLS handshake that the request at
+// the window will never pay. Sending at recv + (window - server) already lands
+// a network round trip late, and only the fixed 100ms goes on top.
+func TestFireTimeDoesNotAddTheProbeRoundTrip(t *testing.T) {
+	recv := time.Date(2026, 9, 8, 7, 53, 13, 153e6, time.Local)
+	s := &clockSync{
+		recv:   recv,
+		rtt:    582 * time.Millisecond,
+		server: recv.Add(541 * time.Millisecond),
+	}
+	window := time.Date(2026, 9, 8, 8, 0, 0, 0, time.Local)
+	got := s.fireTime(window)
+	want := recv.Add(window.Sub(s.server) + 100*time.Millisecond)
+	if !got.Equal(want) {
+		t.Fatalf("fireTime = %s, want %s", got.Format("15:04:05.000"), want.Format("15:04:05.000"))
+	}
+	// The local clock is 541ms behind the server, so add that to read the
+	// fire time on the server's clock.
+	if late := got.Add(541 * time.Millisecond).Sub(window); late != 100*time.Millisecond {
+		t.Fatalf("fires %s after the window by the server's clock, want 100ms", late)
+	}
+}
+
+func TestApplyCodeTimingRejectionKeepsThePlace(t *testing.T) {
+	c := &course{id: "30004-1", next: time.Now().Add(courseCooldown)}
+	applyCode(newTestUI(), c, 1, "NO_REGISTRATION_TIME", 0)
+	if c.judged != 0 || c.parked || c.done {
+		t.Fatalf("judged=%d parked=%t done=%t after NO_REGISTRATION_TIME, want 0 false false", c.judged, c.parked, c.done)
+	}
+	if c.last != "NO_REGISTRATION_TIME" {
+		t.Fatalf("last = %q, want the code recorded", c.last)
+	}
+	applyCode(newTestUI(), c, 2, "CAPACITY_EXCEEDED", 0)
+	if c.judged != 1 {
+		t.Fatalf("judged = %d after a real verdict, want 1", c.judged)
+	}
+}
+
+func TestPostTurnsAnErrorFieldIntoAResult(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"error":"TOO_MANY_REQUESTS"}`)
+	}))
+	defer srv.Close()
+	defer swap(&regEndpoint, srv.URL)()
+
+	cl := &client{http: &http.Client{Timeout: time.Second}}
+	_, _, err := cl.add(&course{id: "30004-1", units: 1})
+
+	var str *stringResult
+	if !errors.As(err, &str) {
+		t.Fatalf("err = %v, want a stringResult", err)
+	}
+	if str.code != "TOO_MANY_REQUESTS" {
+		t.Errorf("code = %q, want TOO_MANY_REQUESTS", str.code)
+	}
+	if holdResults[str.code].hold == 0 {
+		t.Errorf("TOO_MANY_REQUESTS does not hold the shared token")
+	}
+}
+
+// TestWarmUpDoesNotHoldTheWindow: the warm up GET is sent and forgotten. A
+// portal that sits on it must not delay the first real request, and the token
+// still counts from the moment it went out.
+func TestWarmUpDoesNotHoldTheWindow(t *testing.T) {
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-release
+	}))
+	defer srv.Close()
+	defer close(release) // runs before srv.Close, which waits for handlers
+	defer swap(&portalOrigin, srv.URL)()
+
+	cl := &client{http: &http.Client{Timeout: 5 * time.Second}}
+	before := time.Now()
+	cl.warmUp(newTestUI(), before.Add(50*time.Millisecond))
+	if took := time.Since(before); took > 500*time.Millisecond {
+		t.Fatalf("warmUp blocked for %s waiting on an answer that never came", took)
+	}
+	if called := cl.called(); called.Before(before) {
+		t.Fatalf("the token does not count from the warm up: last call %s, warm up at %s", called, before)
+	}
+}
+
 func swap[T any](p *T, v T) func() {
 	old := *p
 	*p = v

--- a/docs/reference/error-codes.md
+++ b/docs/reference/error-codes.md
@@ -41,8 +41,12 @@ explanation so they are obvious at a glance.
 Two groups in the third column get special handling. The timing codes,
 `NO_REGISTRATION_TIME`, `REGISTRATION_TIME_LIMIT`, `NOT_LOGIN_TIME`,
 `LOGIN_TIME_RESTRICTION`, `EDU_TIME` and `CLOSED_INTERVAL`, mean the backend
-refused to look at the course, so they are not counted as verdicts and the
-course keeps its place in the order. `TOO_MANY_REQUESTS`, `PLEASE_WAIT` and
+refused to look at the course. The first one a course gets is not counted as a
+verdict, so an opening request that lands a moment early does not push the
+most contested course to the back of the list. Any further one counts like
+any other retryable result, otherwise a course the portal keeps refusing on
+timing grounds would outrank every course with a real verdict for the rest of
+the run. `TOO_MANY_REQUESTS`, `PLEASE_WAIT` and
 `BLOCKED` are the portal pushing back on the client as a whole, so they hold
 the shared request token the way a `429` does, for 2 seconds, or 30 seconds
 for `BLOCKED`, whose own text says minutes and which follows the student id

--- a/docs/reference/error-codes.md
+++ b/docs/reference/error-codes.md
@@ -38,6 +38,17 @@ course took nine attempts and roughly twenty eight seconds of scheduler time
 under the old rule. Permanent failures are called out in the log with a plain
 explanation so they are obvious at a glance.
 
+Two groups in the third column get special handling. The timing codes,
+`NO_REGISTRATION_TIME`, `REGISTRATION_TIME_LIMIT`, `NOT_LOGIN_TIME`,
+`LOGIN_TIME_RESTRICTION`, `EDU_TIME` and `CLOSED_INTERVAL`, mean the backend
+refused to look at the course, so they are not counted as verdicts and the
+course keeps its place in the order. `TOO_MANY_REQUESTS`, `PLEASE_WAIT` and
+`BLOCKED` are the portal pushing back on the client as a whole, so they hold
+the shared request token the way a `429` does, for 2 seconds, or 30 seconds
+for `BLOCKED`, whose own text says minutes and which follows the student id
+rather than the connection. An `error` field on an object body is read as a
+result code the same way a bare string body is.
+
 ---
 
 ## Full reference

--- a/docs/reference/rate-limits.md
+++ b/docs/reference/rate-limits.md
@@ -41,9 +41,18 @@ Both of run B's timeouts had in fact registered the course. A request that
 gives up client side may still have been carried out, so the answer to a
 timeout is to let the next response tell you, not to resend.
 
+Run A's rejections look inconsistent at first: a request sent 1.101s after the
+previous one was rejected and one sent 1.102s after was accepted. The
+difference is the connection. The request before the rejected one went out on
+a fresh connection and paid a TLS handshake inside its 818ms round trip, so it
+reached the edge several hundred milliseconds after the scheduler sent it and
+the next request followed it there well under a second later. The accepted
+pair were both on a warm connection. Spacing has to be measured from when the
+request is written, which is what the client now does.
+
 Run B also took a second `429` at 08:00:35, a full 5 seconds after its previous
 request and in the same millisecond as the answer to it. Nothing the sniper
-sent explains that. The limiter is keyed on the IP, so the traffic came from
+sent explains that, and it is the one observation no per client model covers. The limiter is keyed on the IP, so the traffic came from
 alongside it: a click in the browser, or another student behind the same NAT.
 The scheduler now treats a `429` as a 2 second hold on the shared token with
 the course keeping its place, which is the right response either way, but a
@@ -83,11 +92,15 @@ that matter.
 | **1.10s** | **12 / 14** | the gap `globalGap` currently uses |
 | 1.30s | 14 / 14 | clean across the whole run |
 
-The underlying limit really is one request per second, as the README says. The
-losses at 1.05s and 1.10s are not a different limit, they are jitter: measured
-round trip time on the same pooled connection ranged from 46ms to 2037ms in a
-single run, so a client gap of 1.10s regularly lands two requests less than a
-second apart at the edge.
+Everything here fits a limit of about one request per second, counted when
+the request arrives at the edge, with the losses at 1.05s and 1.10s being
+jitter: measured round trip time on the same pooled connection ranged from
+46ms to 2037ms in a single run, so a client gap of 1.10s can land two requests
+less than a second apart at the edge. But fitting is not proving. The samples
+are small, 1.2s and 1.5s both passed 10 of 12 where a hard threshold would
+show a step, and 12 of 14 against 14 of 14 is not a significant difference on
+its own. Treat "one per second" as the working model and 1.3s as the working
+default, not as a measured rule.
 
 ### Consequence for `globalGap`
 

--- a/docs/reference/rate-limits.md
+++ b/docs/reference/rate-limits.md
@@ -41,6 +41,20 @@ Both of run B's timeouts had in fact registered the course. A request that
 gives up client side may still have been carried out, so the answer to a
 timeout is to let the next response tell you, not to resend.
 
+Run B also took a second `429` at 08:00:35, a full 5 seconds after its previous
+request and in the same millisecond as the answer to it. Nothing the sniper
+sent explains that. The limiter is keyed on the IP, so the traffic came from
+alongside it: a click in the browser, or another student behind the same NAT.
+The scheduler now treats a `429` as a 2 second hold on the shared token with
+the course keeping its place, which is the right response either way, but a
+browser tab on the portal during the window is a cost you can avoid.
+
+Both runs also got `REPEATED_REQUEST` on a course that then landed from a job
+the sniper had not knowingly queued. The job ids sit where a request sent a
+second or two before the sniper's would sit, which again points at a click in
+the browser, and it is why `REPEATED_REQUEST` is now read as "the portal has
+it" rather than as a failure.
+
 ---
 
 ## 1. The edge limiter on `/api/reg`

--- a/docs/reference/server-contract.md
+++ b/docs/reference/server-contract.md
@@ -11,7 +11,7 @@ This is the summary. The rest of this directory is the detail behind it:
 
 | Measured behaviour | Consequence for the client |
 | --- | --- |
-| The edge allows **exactly one request per second, with no burst**, and rejects the rest with a real HTTP `429` and an HTML body. | A parallel burst throws most of its requests away. Pacing is the single most important thing the client does. |
+| The edge rejects a request that follows the previous one too closely with a real HTTP `429` and an HTML body. Every measurement fits **about one request per second, no burst**, but none proves it. | A parallel burst throws most of its requests away. Pacing is the single most important thing the client does, and the gap is a working default, not a measured threshold. |
 | **Every** request to the host counts, including a plain `GET /`. | Connection warm up must happen well before the window, never immediately before it. |
 | Application errors arrive as **HTTP 200** with an `error` field in the JSON body. | Status codes cannot be used to detect failure, apart from `429`. |
 | Auth failure is `{"error":"AUTHORIZATION"}`, never a `401`. | The token check has to read the body. |
@@ -38,7 +38,7 @@ time and server time agree.
 
 | Row | Detail |
 | --- | --- |
-| one request per second, `429` on the rest | [rate-limits.md](rate-limits.md), including a re-measurement on a warm pooled connection |
+| about one request per second, `429` on the rest | [rate-limits.md](rate-limits.md), including a re-measurement on a warm pooled connection and what the live window did not settle |
 | every request counts, including `GET /` | [rate-limits.md](rate-limits.md#2-which-requests-count-and-which-get-rejected), where counting and rejection turn out to be different sets |
 | errors arrive as HTTP 200 | [http-api.md](http-api.md#conventions) |
 | auth failure is a body, not a `401` | [auth.md](auth.md) |


### PR DESCRIPTION
## What this changes

A second pass over the three transcripts from the 08:00 window on 2026-09-08,
this time against the scheduler that #5 merged. Five holes in the logic, one
pacing change, and the notes to match. Based on #7, which lifts the cap on
answers in flight; merge that first and this rebases onto main cleanly.

- The newest job per course is read whether or not it has a verdict. The reader
  skipped a job without a result and fell through to an older one, which in run
  A reported two courses as `NO_REGISTRATION_TIME` from pre window jobs while
  their real job was still queued. A stale permanent code would have parked the
  course for 45s.
- The warm up is sent and not waited for, and the request token counts from
  the moment a request is written, taken from the `httptrace` callback. The GET
  was synchronous and the first token counted from its response, so a slow GET
  would have held the window, up to the 10s timeout.
- The first timing code a course gets (`NO_REGISTRATION_TIME` and friends)
  does not count as a verdict. Under fewest verdicts first, one early arrival
  demoted the most contested course behind the whole list. Only the first is
  free: a course the portal keeps refusing on timing grounds while the others
  get real verdicts would otherwise sit at judged 0 and outrank all of them
  for the rest of the run. A test covers that partial window shape.
- An `error` field on an object body is read as a result code. `BLOCKED` or
  `NO_REMAINED_ACTION` used to print as `REQUEST FAILED` with "it may still
  have been carried out". `TOO_MANY_REQUESTS` and `PLEASE_WAIT` now hold the
  shared token for 2s and `BLOCKED` for 30s, the course keeping its place, the
  way a `429` does.
- The fire time no longer adds the probe's round trip. Sending at
  `recv + (window - server)` already arrives a network round trip late, and
  the probe runs on a cold connection so its round trip included a TLS
  handshake: run A fired 1.2s after the window for nothing. The 100ms margin
  stays.

- The one request per second claim is softened to what is known, in the README,
  the server contract, the rate limit notes and the code comments. Every
  measurement fits about one per second counted at arrival, none proves it,
  and the samples are small. Run A's apparent contradiction, a rejection at
  1.101s and a pass at 1.102s, is the cold connection: the request before the
  rejected one paid a TLS handshake inside its round trip, so it reached the
  edge late and the next one followed under a second behind it. That is the
  case the write time token above fixes. 1.3s stays as the working default.

## Why

Run B took a second `429` five seconds after its previous request, in the same
millisecond as the answer to it, which its own traffic cannot explain, and
both runs got `REPEATED_REQUEST` on a course that then landed from a job the
sniper had not knowingly queued. Both point at a browser click alongside the
sniper, so the README now says to leave the portal alone during the run, and
the rate limit notes record what was seen.

## How it was verified

- `go test -race ./...`, 21 tests. New ones pin the stale verdict shape from
  run A, the first timing code keeping its place and the second counting, the
  error field becoming a result, the warm up returning without an answer while
  the token still counts from it, and the fire time arithmetic.
- `gofmt`, `go vet` and `go build` are clean.
- `curl` against the live host confirmed HTTP/2, which the warm up relies on
  to carry the first POST while its GET is still outstanding.
- Not exercised against a live registration window. The next one is the test.

## If it touches timing

- Fire time: `recv + (window - server) + 100ms`, was `+ roundTrip` on top.
  From the two transcripts, the probe round trip was 582ms on a cold
  connection in run A and 74ms in run B, so the old formula arrived 1.26s and
  0.25s after the window. The new one arrives one warm round trip plus 100ms
  after it, on the same two samples about 250ms and 150ms.
- `blockedBackoff` 30s, new. `BLOCKED` has never been seen live; its own text
  says minutes and it follows the student id, so probing sooner cannot help.
- `globalGap`, `courseCooldown` and `rateLimitBackoff` are unchanged.

## Checklist

- [x] `gofmt -l ./cmd ./tools` prints nothing
- [x] `go vet ./...` and `go build ./...` are clean
- [x] No new dependency, and `cmd/sniper` is still standard library only
- [x] No token, transcript or student identifier in the diff
- [x] README or `docs/reference` updated if behaviour changed
