### PR TITLE
Add a probe that measures what the edge actually rejects

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ Log in at [my.edu.sharif.edu](https://my.edu.sharif.edu) shortly before your
 window, open the browser network tab, and copy the `Authorization` request
 header from any API call. Sessions last roughly an hour.
 
+Then leave the portal alone until the run is over. The edge limiter counts
+every request from your IP, so a click in the browser during the window costs
+the sniper a `429`, and one run on 2026-09-08 took a rejection that its own
+traffic cannot explain.
+
 Every run prints its version in the banner and the transcript, and
 `sniper -version` reports it on its own. Quote it in any bug report.
 
@@ -227,13 +232,19 @@ toward the window. Given a probe sent at `t0`, answered at `t1`, with the
 server reporting `S` and the window at `R`:
 
 ```
-fire = t1 + (R - S) + roundTrip + 100ms
+fire = t1 + (R - S) + 100ms
 ```
 
-The margin is biased late deliberately. Arriving early is rejected **and**
-burns that course's five second cooldown, so a request 100ms early costs about
-five seconds. A request 100ms late costs 100ms. The client prints this
-derivation with your actual numbers before it commits to a fire time.
+That is later than it looks. The server stamps `S` as it answers, so by `t1`
+its clock is already half a round trip past `S`, and the request spends the
+other half on the way in: it reaches the server a full network round trip
+after the window opens, plus the 100ms. The margin is biased late
+deliberately, because arriving early is rejected and puts that course on its
+five second cooldown, while arriving late costs only the delay. The formula
+used to add the probe's round trip too, and since the probe runs on a cold
+connection that included a TLS handshake: one run on 2026-09-08 fired 1.2s
+after the window for nothing. The client prints the derivation with your
+actual numbers before it commits to a fire time.
 
 ## Decision 5: units come from the catalogue
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ sequenceDiagram
 
     Note over C: heartbeat, then a per second countdown
     C->>S: GET / at two seconds out, to warm the connection
-    Note over C: the warm up finishes before the window, it spends a token too
+    Note over C: the warm up is sent and not waited for, it spends a token too
 
     Note over C,S: the burst, one request per 1.3s
     loop until every course lands or you stop it
@@ -175,9 +175,29 @@ timeout. A scheduler that waits for each answer before sending the next request
 is paced by the portal's latency rather than by the edge limit, which is the
 one thing it was built to respect.
 
-So the token spacing governs when a request leaves, and up to `-inflight`
-requests may be waiting for an answer at once. The portal has a concurrency
-guard of its own, `TOO_MANY_REQUESTS`, so the default is a modest 3.
+So the token spacing alone governs when a request leaves, and answers land
+whenever they land. There is no cap on outstanding answers by default, because
+the scheduler is already bounded twice over: a course with a request in flight
+is never picked again, so there is at most one per course, and no request
+outlives the 10 second timeout. The ceiling is the smaller of your list length
+and `timeout / gap`, about eight at the defaults.
+
+A cap below that ceiling throttles *sending* rather than answering. With answers
+taking `T` seconds and a cap of `C`, a request can only leave every `T / C`
+seconds, so a cap of 3 against the 5 second answers measured inside the window
+paces you at 1.7s, slower than the edge actually allows. Modelled on the
+2026-09-08 shape, ten courses with three second answers and two requests that
+hang to the timeout, the last course on the list gets its first attempt at:
+
+| | last course's first attempt |
+| --- | --- |
+| `-inflight 3` | 15.2s |
+| uncapped, the default | 11.7s |
+
+11.7s is exactly ten tokens at 1.3s, which is the floor. `-inflight` remains as
+an escape hatch for `TOO_MANY_REQUESTS`, the portal's own concurrency guard,
+which has never been seen live. `-inflight 1` restores the old serial
+behaviour.
 
 ## Decision 3: every course before any second attempt
 
@@ -278,7 +298,7 @@ curl https://erfnzdeh.github.io/my.edu.sharif.edu-sniper/api/courses.json
 | `-catalogue` | Path or URL of `courses.json`. |
 | `-transcript` | Transcript path. Defaults to `snipe-<timestamp>.log`. |
 | `-gap` | Minimum spacing between two requests. Defaults to `1.3s`. |
-| `-inflight` | How many requests may wait for an answer at once. Defaults to `3`. |
+| `-inflight` | Cap on requests waiting for an answer. Defaults to `0`, no cap. |
 | `-version` | Print the version, platform and Go version, then exit. |
 
 Exit codes: `0` when everything landed, `1` when something is still

--- a/README.md
+++ b/README.md
@@ -140,11 +140,15 @@ sequenceDiagram
 
 ---
 
-## Decision 1: pace at one request per second
+## Decision 1: pace at about one request per second
 
-This is the whole game. The edge allows one request per second, applied per
-client, and rejects the excess with a real `429` rather than queueing it. A
-parallel burst therefore throws most of its requests away. Full measurements in
+This is the whole game. The edge rejects requests that follow too closely on
+the previous one from the same IP with a real `429` rather than queueing them,
+so a parallel burst throws most of its requests away. How close is too close
+is not known exactly. Every measurement so far fits a limit of about one
+request per second counted when the request arrives, but none of them proves
+it, and one rejection on 2026-09-08 came five seconds after anything the
+sniper had sent. Full measurements, and what they do not settle, are in
 [docs/reference/rate-limits.md](docs/reference/rate-limits.md).
 
 So the scheduler holds a single global token, released every 1.3 seconds, and
@@ -168,9 +172,13 @@ between attempts at the same course, and the global rule is one request per
 second overall. With five or more courses the global rule already satisfies
 the per course one, and below that the per course cooldown binds.
 
-The gap is 1.3 seconds rather than 1.1 because round trip jitter regularly
-lands two requests less than a second apart at the edge. At 1.1s about one
-request in seven came back `429`, which buys nothing.
+The gap is 1.3 seconds rather than 1.1 because at 1.1s about one request in
+seven came back `429` on 2026-09-07, and at 1.3s none did. That is a small
+sample and a working default rather than a measured threshold, which is why
+`-gap` exists. The token is counted from the moment a request is written to
+the connection, not from when the scheduler decided to send it, because a
+request that has to open a connection first reaches the edge several hundred
+milliseconds later than one on a warm connection.
 
 ## Decision 2: sending does not wait for the answer
 

--- a/cmd/sniper/main.go
+++ b/cmd/sniper/main.go
@@ -77,13 +77,21 @@ var (
 	// which is a bad trade now that a rejection is cheap but not free.
 	// See docs/reference/rate-limits.md.
 	globalGap = 1300 * time.Millisecond
-	// maxInflight is how many requests may be waiting for an answer at once.
-	// Inside the window a single answer took two to five seconds, and one
-	// that timed out held the whole queue for ten, so a strictly serial
-	// scheduler spends the contested seconds waiting rather than asking.
-	// The portal has a concurrency guard of its own, TOO_MANY_REQUESTS, so
-	// this stays small.
-	maxInflight = 3
+	// maxInflight caps how many requests may be waiting for an answer at
+	// once. Zero, the default, means no cap, because the scheduler is
+	// already bounded twice over: a course with a request in flight is never
+	// picked again, so there is at most one per course, and no request can
+	// outlive httpTimeout. The real ceiling is the smaller of the list
+	// length and httpTimeout/globalGap, which is about eight at the
+	// defaults.
+	//
+	// A cap below that ceiling throttles sending rather than answering. At
+	// the five second answers measured inside the window, a cap of three
+	// lets a request leave only every 1.7s, which is slower than the gap the
+	// edge actually allows, so the cap and not the limiter sets the pace.
+	// It stays as an escape hatch for TOO_MANY_REQUESTS, the portal's own
+	// concurrency guard, which has never been seen live.
+	maxInflight = 0
 )
 
 // Result codes, taken from the portal frontend bundle.
@@ -231,7 +239,7 @@ func run() int {
 		fCatalogue  = flag.String("catalogue", "", "path or URL of courses.json, overrides the default lookup")
 		fTranscript = flag.String("transcript", "", "transcript file path, defaults to snipe-<timestamp>.log")
 		fGap        = flag.Duration("gap", globalGap, "minimum spacing between two requests, the edge allows one per second")
-		fInflight   = flag.Int("inflight", maxInflight, "how many requests may wait for an answer at once")
+		fInflight   = flag.Int("inflight", maxInflight, "cap on requests waiting for an answer at once, 0 for no cap")
 		fVersion    = flag.Bool("version", false, "print the version and exit")
 	)
 	flag.Parse()
@@ -241,8 +249,8 @@ func run() int {
 		globalGap = 100 * time.Millisecond
 	}
 	maxInflight = *fInflight
-	if maxInflight < 1 {
-		maxInflight = 1
+	if maxInflight < 0 {
+		maxInflight = 0
 	}
 
 	if *fVersion {
@@ -282,11 +290,20 @@ func run() int {
 	ui.tr = tr
 	ui.info("transcript %s", tr.path)
 	tr.write("BUILD    %s %s/%s %s", buildVersion(), runtime.GOOS, runtime.GOARCH, runtime.Version())
-	tr.write("PACING   gap=%s cooldown=%s inflight=%d rateLimitBackoff=%s parkedBackoff=%s timeout=%s",
-		globalGap, courseCooldown, maxInflight, rateLimitBackoff, parkedBackoff, httpTimeout)
+	tr.write("PACING   gap=%s cooldown=%s inflight=%s rateLimitBackoff=%s parkedBackoff=%s timeout=%s",
+		globalGap, courseCooldown, inflightNote(len(courses)), rateLimitBackoff, parkedBackoff, httpTimeout)
 
+	// The default transport keeps two idle connections per host, so with
+	// answers overlapping, the third concurrent request onwards would find an
+	// empty pool and pay a fresh TLS handshake, measured at about 650ms, every
+	// time it went out. Keep one warm connection per course instead. If the
+	// portal speaks HTTP/2 this is moot, since one connection carries them
+	// all: the transcript's proto= field says which happened.
+	pool := http.DefaultTransport.(*http.Transport).Clone()
+	pool.MaxIdleConns = 4 * len(courses)
+	pool.MaxIdleConnsPerHost = 2 * len(courses)
 	cl := &client{
-		http:  &http.Client{Timeout: httpTimeout},
+		http:  &http.Client{Timeout: httpTimeout, Transport: pool},
 		token: token,
 		tr:    tr,
 	}
@@ -368,7 +385,7 @@ func fireWindow(parent context.Context, ui *ui, cl *client, courses []*course) b
 		// the client made rather than from now.
 		nextSend = cl.called().Add(globalGap)
 	)
-	slots := make(chan struct{}, maxInflight)
+	slots := make(chan struct{}, inflightCap(len(courses)))
 	wake := make(chan struct{}, 1)
 	notify := func() {
 		select {
@@ -470,6 +487,23 @@ func fireWindow(parent context.Context, ui *ui, cl *client, courses []*course) b
 
 	wg.Wait()
 	return authBad
+}
+
+// inflightCap is how many answers may be outstanding. A course with a request
+// in flight is never picked again, so the length of the list is a hard ceiling
+// and an uncapped run simply uses it.
+func inflightCap(courses int) int {
+	if maxInflight <= 0 || maxInflight > courses {
+		return courses
+	}
+	return maxInflight
+}
+
+func inflightNote(courses int) string {
+	if maxInflight <= 0 {
+		return fmt.Sprintf("uncapped, ceiling %d", inflightCap(courses))
+	}
+	return strconv.Itoa(maxInflight)
 }
 
 // choose returns the course that should get the next token, and the soonest
@@ -1237,7 +1271,7 @@ func confirm(ui *ui, courses []*course, s *clockSync, target, fireAt time.Time, 
 	}
 	ui.plain("  window opens  %s", target.Format("2006-01-02 15:04:05.000"))
 	ui.plain("  firing at     %s (in %s)", fireAt.Format("15:04:05.000"), time.Until(fireAt).Truncate(time.Millisecond))
-	ui.plain("  pacing        one request every %s, %s per course, up to %d in flight", globalGap, courseCooldown, maxInflight)
+	ui.plain("  pacing        one request every %s, %s per course, up to %d in flight", globalGap, courseCooldown, inflightCap(len(courses)))
 	if yes {
 		return true
 	}

--- a/cmd/sniper/main.go
+++ b/cmd/sniper/main.go
@@ -1,8 +1,9 @@
 // Command sniper registers courses on my.edu.sharif.edu the moment the
 // registration window opens.
 //
-// The portal's edge allows exactly one request per second with no burst, so
-// the scheduler spends one request token at a time. Every course gets its
+// The portal's edge rejects a request that follows the previous one too
+// closely, and everything measured so far fits about one per second with no
+// burst, so the scheduler spends one request token at a time. Every course gets its
 // first attempt before any course gets its second, and within the same
 // attempt count list order is priority order. Answers take seconds to come
 // back, so a few requests may be waiting at once: the token spacing is what
@@ -75,10 +76,11 @@ const (
 // Pacing, overridable from the command line because the right values depend
 // on the link and both cost something when they are wrong.
 var (
-	// globalGap is the minimum spacing between two requests. The edge allows
-	// one per second and counts every request to the host, including the warm
-	// up. A 1.1s gap loses about one request in seven to round trip jitter,
-	// which is a bad trade now that a rejection is cheap but not free.
+	// globalGap is the minimum spacing between two requests. The edge looks
+	// like about one per second, and counts every request to the host,
+	// including the warm up. A 1.1s gap lost about one request in seven to
+	// round trip jitter, which is a bad trade now that a rejection is cheap
+	// but not free. A working default from small samples, hence the flag.
 	// See docs/reference/rate-limits.md.
 	globalGap = 1300 * time.Millisecond
 	// maxInflight caps how many requests may be waiting for an answer at
@@ -208,6 +210,7 @@ type course struct {
 	next     time.Time // not eligible to be retried before this
 	pending  bool      // a request is in flight right now
 	parked   bool      // last result cannot change on a retry
+	early    int       // timing rejections so far, only the first is free
 	done     bool
 	landed   time.Time
 	last     string // most recent result seen
@@ -266,7 +269,7 @@ func run() int {
 		fYes        = flag.Bool("y", false, "skip the confirmation prompt, requires -token and -courses")
 		fCatalogue  = flag.String("catalogue", "", "path or URL of courses.json, overrides the default lookup")
 		fTranscript = flag.String("transcript", "", "transcript file path, defaults to snipe-<timestamp>.log")
-		fGap        = flag.Duration("gap", globalGap, "minimum spacing between two requests, the edge allows one per second")
+		fGap        = flag.Duration("gap", globalGap, "minimum spacing between two requests, the edge allows about one per second")
 		fInflight   = flag.Int("inflight", maxInflight, "cap on requests waiting for an answer at once, 0 for no cap")
 		fVersion    = flag.Bool("version", false, "print the version and exit")
 	)
@@ -324,9 +327,10 @@ func run() int {
 	// The default transport keeps two idle connections per host, so with
 	// answers overlapping, the third concurrent request onwards would find an
 	// empty pool and pay a fresh TLS handshake, measured at about 650ms, every
-	// time it went out. Keep one warm connection per course instead. If the
-	// portal speaks HTTP/2 this is moot, since one connection carries them
-	// all: the transcript's proto= field says which happened.
+	// time it went out. Keep one warm connection per course instead. The
+	// portal negotiates HTTP/2, checked on 2026-09-08, so one connection
+	// carries them all and this only matters on a fallback to HTTP/1.1: the
+	// transcript's proto= field says which happened.
 	pool := http.DefaultTransport.(*http.Transport).Clone()
 	pool.MaxIdleConns = 4 * len(courses)
 	pool.MaxIdleConnsPerHost = 2 * len(courses)
@@ -704,12 +708,20 @@ func applyCode(ui *ui, c *course, attempt int, res string, rtt time.Duration) {
 	note := fmt.Sprintf("retry at %s", c.next.Format("15:04:05.000"))
 	k := kindBad
 	if why, timing := timingResults[res]; timing {
-		// The backend refused to look at the course, so this is not a verdict
-		// on it. It keeps its rank rather than falling behind every course
-		// tried after it, which matters most for the first course on the list
-		// when the opening request lands a moment early.
-		ui.attempt(c, attempt, res, why+", keeps its place", rtt, kindWarn)
-		return
+		c.early++
+		if c.early == 1 {
+			// The backend refused to look at the course, so this is not a
+			// verdict on it. It keeps its rank rather than falling behind
+			// every course tried after it, which matters most for the first
+			// course on the list when the opening request lands a moment
+			// early. Only the first one is free: a course the portal keeps
+			// refusing on timing grounds while the others get real verdicts
+			// would otherwise sit at judged 0 and outrank all of them for
+			// the rest of the run.
+			ui.attempt(c, attempt, res, why+", keeps its place", rtt, kindWarn)
+			return
+		}
+		note = why + ", " + note
 	}
 	c.judged++
 	if why, queued := queuedResults[res]; queued {

--- a/cmd/sniper/main.go
+++ b/cmd/sniper/main.go
@@ -52,6 +52,10 @@ const (
 	// freeze costs far more than the rejection did: on 2026-09-08 two 429s
 	// cost fourteen seconds of the most contested part of the window.
 	rateLimitBackoff = 2 * time.Second
+	// How long to hold every request after the portal reports BLOCKED. Its
+	// own text says minutes, and the block follows the student id rather than
+	// the connection, so there is nothing to gain by probing sooner.
+	blockedBackoff = 30 * time.Second
 	// How long to hold back a course whose result cannot change on a retry.
 	// It is still retried, because the operator may drop the course it
 	// clashes with, but it must not crowd out a course that can still land.
@@ -136,6 +140,30 @@ var permanentFailures = map[string]string{
 var queuedResults = map[string]string{
 	"REPEATED_REQUEST": "the portal already has this exact job queued",
 	"ALREADY_IN_QUEUE": "a job for this course is already queued",
+}
+
+// timingResults mean the backend refused to look at the course at all, so
+// they are not verdicts on it and do not count against it in the ordering.
+var timingResults = map[string]string{
+	"NO_REGISTRATION_TIME":    "registration is not open",
+	"REGISTRATION_TIME_LIMIT": "not your registration slot",
+	"NOT_LOGIN_TIME":          "not your registration slot",
+	"LOGIN_TIME_RESTRICTION":  "not your login window",
+	"EDU_TIME":                "the portal is only live 08:00 to 12:00",
+	"CLOSED_INTERVAL":         "the portal is closed at this hour",
+}
+
+// holdResults are the portal pushing back on the client as a whole rather
+// than judging a course, so they hold the shared token the way a 429 does.
+// None has been seen live. BLOCKED says "try again in a few minutes", and it
+// is keyed on the student id, so hammering through it can only prolong it.
+var holdResults = map[string]struct {
+	why  string
+	hold time.Duration
+}{
+	"TOO_MANY_REQUESTS": {"too many requests outstanding, lower -inflight if this repeats", rateLimitBackoff},
+	"PLEASE_WAIT":       {"the portal's upstream is struggling", rateLimitBackoff},
+	"BLOCKED":           {"your student id is restricted for excess requests", blockedBackoff},
 }
 
 type catalogueEntry struct {
@@ -396,6 +424,12 @@ func fireWindow(parent context.Context, ui *ui, cl *client, courses []*course) b
 
 	for ctx.Err() == nil {
 		mu.Lock()
+		// The client records when each request was actually written, which
+		// is later than the scheduler's send time on a cold connection, and
+		// the warm up writes a request the scheduler never sent at all.
+		if ns := cl.called().Add(globalGap); ns.After(nextSend) {
+			nextSend = ns
+		}
 		finished, wait := allDone(courses), time.Until(nextSend)
 		mu.Unlock()
 		if finished {
@@ -464,8 +498,18 @@ func fireWindow(parent context.Context, ui *ui, cl *client, courses []*course) b
 				authBad = true
 				ui.fatal("token rejected or expired, log in again and rerun")
 				cancel()
+			case errors.As(err, &str) && holdResults[str.code].hold > 0:
+				// The portal is pushing back on the client as a whole, not on
+				// this course, so hold the shared token and let the course
+				// keep its place, exactly as for a 429.
+				h := holdResults[str.code]
+				c.last = str.code
+				c.next = sent
+				if back := time.Now().Add(h.hold); back.After(nextSend) {
+					nextSend = back
+				}
+				ui.attempt(c, attempt, str.code, fmt.Sprintf("%s, next token in %s", h.why, h.hold), rtt, kindWarn)
 			case errors.As(err, &str):
-				c.judged++
 				applyCode(ui, c, attempt, str.code, rtt)
 			case err != nil:
 				// A request that gave up client side may still have been
@@ -476,7 +520,6 @@ func fireWindow(parent context.Context, ui *ui, cl *client, courses []*course) b
 				c.last = "error"
 				ui.attempt(c, attempt, "REQUEST FAILED", err.Error()+" (it may still have been carried out)", rtt, kindWarn)
 			default:
-				c.judged++
 				applyJobs(ui, courses, c, attempt, resp, rtt)
 				ui.setRemaining(resp.RemainingActions)
 			}
@@ -611,16 +654,22 @@ func orDash(s string) string {
 // harvests successes for any other course. jobs is newest first and
 // accumulates across the whole session, so the first match is the latest.
 func applyJobs(ui *ui, courses []*course, pick *course, attempt int, resp *regResponse, rtt time.Duration) {
+	// The newest job per course, judged or not. Skipping an unjudged job
+	// would fall through to an older one: on 2026-09-08 that read a pre
+	// window NO_REGISTRATION_TIME as the verdict on a course whose real job
+	// was still queued. Had the stale result been a permanent failure the
+	// course would have been parked for nothing.
 	seen := map[string]string{}
 	for _, j := range resp.Jobs {
-		if _, ok := seen[j.CourseID]; !ok && j.Result != "" {
+		if _, ok := seen[j.CourseID]; !ok {
 			seen[j.CourseID] = j.Result
 		}
 	}
 
-	if res, ok := seen[pick.id]; ok {
+	if res, ok := seen[pick.id]; ok && res != "" {
 		applyCode(ui, pick, attempt, res, rtt)
-	} else {
+	} else if !pick.done {
+		pick.judged++
 		pick.last = "QUEUED"
 		ui.attempt(pick, attempt, "QUEUED", "server has not judged it yet", rtt, kindWarn)
 	}
@@ -654,6 +703,15 @@ func applyCode(ui *ui, c *course, attempt int, res string, rtt time.Duration) {
 	c.last = res
 	note := fmt.Sprintf("retry at %s", c.next.Format("15:04:05.000"))
 	k := kindBad
+	if why, timing := timingResults[res]; timing {
+		// The backend refused to look at the course, so this is not a verdict
+		// on it. It keeps its rank rather than falling behind every course
+		// tried after it, which matters most for the first course on the list
+		// when the opening request lands a moment early.
+		ui.attempt(c, attempt, res, why+", keeps its place", rtt, kindWarn)
+		return
+	}
+	c.judged++
 	if why, queued := queuedResults[res]; queued {
 		note = why + ", waiting for its verdict instead of resending"
 		k = kindWarn
@@ -738,13 +796,14 @@ type client struct {
 	lastCall time.Time
 }
 
-// stringResult is a bare quoted string body, like
+// stringResult is a result code that arrived without a jobs array: either a
+// bare quoted string body, like
 //
 //	"REPEATED_REQUEST 40111099930004-11add"
 //
-// which is what the portal answers when it declines to queue the job at all.
-// The body carries no jobs array, so there is nothing to harvest from it and
-// the only way to learn the verdict is a later response.
+// which is what the portal answers when it declines to queue the job at all,
+// or the error field of an object. There is nothing to harvest from either,
+// and the only way to learn a queued job's verdict is a later response.
 type stringResult struct {
 	code   string
 	detail string
@@ -832,7 +891,9 @@ func (c *client) post(body regRequest) (*regResponse, time.Duration, error) {
 		return nil, rtt, errAuth
 	}
 	if out.Error != "" {
-		return nil, rtt, fmt.Errorf("%s", out.Error)
+		// An error field is a result code too, BLOCKED or NO_REMAINED_ACTION
+		// for instance, so it takes the same path as a bare string body.
+		return nil, rtt, &stringResult{code: out.Error}
 	}
 	return &out, rtt, nil
 }
@@ -860,18 +921,21 @@ func (c *client) do(req *http.Request, seq int) (*http.Response, []byte, time.Du
 		TLSHandshakeStart: func() { tlsAt = time.Now() },
 		TLSHandshakeDone:  func(tls.ConnectionState, error) { handshake = time.Since(tlsAt) },
 		// More than one write means net/http replayed the request on a fresh
-		// connection, which for an add would queue the job twice.
-		WroteRequest:         func(httptrace.WroteRequestInfo) { writes++ },
+		// connection, which for an add would queue the job twice. The write
+		// is also the moment the edge starts counting, so it is what the
+		// token is measured from.
+		WroteRequest: func(httptrace.WroteRequestInfo) {
+			writes++
+			c.mu.Lock()
+			c.lastCall = time.Now()
+			c.mu.Unlock()
+		},
 		GotFirstResponseByte: func() { ttfb = time.Since(start) },
 	}))
 
 	start = time.Now()
 	res, err := c.http.Do(req)
 	rtt := time.Since(start)
-
-	c.mu.Lock()
-	c.lastCall = time.Now()
-	c.mu.Unlock()
 
 	if err != nil {
 		c.tr.write("ERROR    #%d after %s: %v", seq, rtt.Truncate(time.Millisecond), err)
@@ -931,7 +995,13 @@ func clip(raw []byte, n int) string {
 // warmUp opens a connection shortly before the window so the first real
 // request does not pay a TLS handshake, which measured about 650ms. The GET
 // spends a rate limit token like any other request to the host, so it has to
-// finish a full gap before the window rather than inside it.
+// go out a full gap before the window rather than inside it.
+//
+// It does not wait for the answer. The token is spent when the request is
+// written, and a GET that is slow to come back must not hold the window: the
+// portal speaks HTTP/2, so the connection carries the first POST while the GET
+// is still outstanding, and if the connection never came up the first POST
+// dials one, which is all it would have done without a warm up.
 func (c *client) warmUp(ui *ui, fireAt time.Time) {
 	if since := time.Since(c.called()); since < warmupSkipIfNewerThan {
 		ui.info("warm up  skipped, connection pooled %s ago", since.Truncate(time.Second))
@@ -949,15 +1019,23 @@ func (c *client) warmUp(ui *ui, fireAt time.Time) {
 	c.tr.write("WARMUP   #%d GET %s/ at %s, %s before the window",
 		seq, portalOrigin, time.Now().Format("15:04:05.000"), time.Until(fireAt).Truncate(time.Millisecond))
 	start := time.Now()
-	if _, _, _, err := c.do(req, seq); err != nil {
-		ui.warn("warm up failed: %v", err)
-		return
-	}
-	left := time.Until(fireAt).Truncate(time.Millisecond)
-	ui.info("warm up  connection opened in %dms, %s before the window", time.Since(start).Milliseconds(), left)
-	if left < globalGap {
-		ui.warn("warm up  it ate into the first token, the opening request may be rejected")
-	}
+	// Count the token from now, in case the request is never written. The
+	// trace moves it to the actual write once that happens.
+	c.mu.Lock()
+	c.lastCall = start
+	c.mu.Unlock()
+	go func() {
+		if _, _, _, err := c.do(req, seq); err != nil {
+			ui.warn("warm up failed: %v, the first request will open its own connection", err)
+			return
+		}
+		took := time.Since(start).Milliseconds()
+		if left := time.Until(fireAt); left > 0 {
+			ui.info("warm up  connection opened in %dms, %s before the window", took, left.Truncate(time.Millisecond))
+		} else {
+			ui.warn("warm up  answered in %dms, %s after the window opened", took, (-left).Truncate(time.Millisecond))
+		}
+	}()
 }
 
 // ---------------------------------------------------------------- clock sync
@@ -997,11 +1075,19 @@ func (c *client) syncClock(co *course) (*clockSync, error) {
 	return s, nil
 }
 
-// fireTime keeps the formula the original script has always used. The margin
-// is deliberately biased late: arriving early is rejected and costs a full
-// cooldown, while arriving late costs only the delay itself.
+// fireTime is when the first request leaves. The server stamps its clock as
+// it answers, so at recv the server is already half a round trip past that
+// stamp, and the request spends the other half on the way in: sending at
+// recv + (window - server) lands a whole network round trip after the window
+// opens. The 100ms on top keeps it late through clock granularity and any
+// asymmetry, because arriving early is rejected while arriving late costs
+// only the delay itself.
+//
+// The formula used to add the probe's round trip as well, and the probe runs
+// on a cold connection, so that included a TLS handshake: one run on
+// 2026-09-08 fired 1.2s after the window for nothing.
 func (s *clockSync) fireTime(target time.Time) time.Time {
-	delay := target.Sub(s.server) + s.rtt + 100*time.Millisecond
+	delay := target.Sub(s.server) + 100*time.Millisecond
 	return s.recv.Add(delay)
 }
 
@@ -1509,9 +1595,11 @@ func (u *ui) showClockSync(s *clockSync) {
 func (u *ui) showFireTime(s *clockSync, target, fireAt time.Time) {
 	gap := target.Sub(s.server)
 	u.plain("")
-	u.plain("  fire = received + (window - serverClock) + roundTrip + 100ms")
-	u.plain("       = %s + %s + %s + 100ms",
-		s.recv.Format("15:04:05.000"), gap.Truncate(time.Millisecond), s.rtt.Truncate(time.Millisecond))
+	u.plain("  fire = received + (window - serverClock) + 100ms")
+	u.plain("       = %s + %s + 100ms",
+		s.recv.Format("15:04:05.000"), gap.Truncate(time.Millisecond))
+	u.plain("  %s", u.paint(cDim, fmt.Sprintf("the request lands a network round trip after that, about %s here",
+		s.rtt.Truncate(time.Millisecond))))
 	u.plain("       = %s", u.paint(cBold, fireAt.Format("15:04:05.000")))
 	u.plain("  %s", u.paint(cDim, "the margin is biased late on purpose: arriving early is rejected"))
 	u.plain("  %s", u.paint(cDim, "and costs a full cooldown, arriving late costs only the delay"))

--- a/cmd/sniper/sniper_test.go
+++ b/cmd/sniper/sniper_test.go
@@ -139,7 +139,7 @@ func TestFireWindowLandsEveryCourseWhileAnswersAreSlow(t *testing.T) {
 
 	defer swap(&regEndpoint, srv.URL)()
 	defer swap(&globalGap, 40*time.Millisecond)()
-	defer swap(&maxInflight, 3)()
+	defer swap(&maxInflight, 3)() // pinned, this test is about the cap holding
 
 	courses := mkCourses("a", "b", "c", "d", "e", "f")
 	cl := &client{http: &http.Client{Timeout: 5 * time.Second}}
@@ -158,13 +158,14 @@ func TestFireWindowLandsEveryCourseWhileAnswersAreSlow(t *testing.T) {
 			t.Errorf("%s never landed", c.id)
 		}
 	}
-	// Serially this is six courses times a 300ms answer. Overlapping them has
-	// to beat that clearly, or the concurrency is not doing anything.
+	// The structural check is the real one: requests have to overlap at all.
 	if p.maxAtOnce < 2 {
 		t.Errorf("never had more than %d request in flight, requests are not overlapping", p.maxAtOnce)
 	}
-	if took > 1500*time.Millisecond {
-		t.Errorf("took %s, want well under the 1.8s a serial run would need", took)
+	// The timing check is bounded by what a serial run would cost rather than
+	// by a fixed number, so a loaded machine cannot fail it on its own.
+	if serial := time.Duration(len(courses)) * p.delay; took >= serial {
+		t.Errorf("took %s, a serial run would have been %s, so nothing was gained", took, serial)
 	}
 	if p.maxAtOnce > maxInflight {
 		t.Errorf("%d requests were in flight at once, the cap is %d", p.maxAtOnce, maxInflight)
@@ -174,6 +175,76 @@ func TestFireWindowLandsEveryCourseWhileAnswersAreSlow(t *testing.T) {
 
 // TestFireWindowKeepsTheGapWhenAnswersAreInstant guards the case the edge
 // actually rejects: two requests less than a token apart.
+// TestFireWindowUncappedUsesTheWholeList is the default shape: no cap, so the
+// only ceiling is one request per course. It has to overlap more than the old
+// fixed cap of three would have allowed.
+func TestFireWindowUncappedUsesTheWholeList(t *testing.T) {
+	p := &portal{delay: 700 * time.Millisecond, registered: map[string]bool{}}
+	srv := httptest.NewServer(p)
+	defer srv.Close()
+
+	defer swap(&regEndpoint, srv.URL)()
+	defer swap(&globalGap, 40*time.Millisecond)()
+	defer swap(&maxInflight, 0)() // no cap
+
+	courses := mkCourses("a", "b", "c", "d", "e", "f")
+	cl := &client{http: &http.Client{Timeout: 5 * time.Second}}
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+	defer cancel()
+
+	fireWindow(ctx, newTestUI(), cl, courses)
+
+	for _, c := range courses {
+		if !c.done {
+			t.Errorf("%s never landed", c.id)
+		}
+	}
+	if p.maxAtOnce <= 3 {
+		t.Errorf("peaked at %d in flight, an uncapped run with 700ms answers should beat the old cap of 3", p.maxAtOnce)
+	}
+	if p.maxAtOnce > len(courses) {
+		t.Errorf("%d in flight for %d courses, a course must never have two requests out at once", p.maxAtOnce, len(courses))
+	}
+	assertSpacing(t, p.arrivals, globalGap)
+}
+
+// TestFireWindowInflightOneIsSerial checks the escape hatch still works, since
+// it is what someone would reach for if TOO_MANY_REQUESTS ever showed up.
+func TestFireWindowInflightOneIsSerial(t *testing.T) {
+	p := &portal{delay: 200 * time.Millisecond, registered: map[string]bool{}}
+	srv := httptest.NewServer(p)
+	defer srv.Close()
+
+	defer swap(&regEndpoint, srv.URL)()
+	defer swap(&globalGap, 20*time.Millisecond)()
+	defer swap(&maxInflight, 1)()
+
+	courses := mkCourses("a", "b", "c")
+	cl := &client{http: &http.Client{Timeout: 5 * time.Second}}
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+	defer cancel()
+
+	fireWindow(ctx, newTestUI(), cl, courses)
+	if p.maxAtOnce != 1 {
+		t.Errorf("peaked at %d in flight, -inflight 1 must stay serial", p.maxAtOnce)
+	}
+}
+
+func TestInflightCapNeverExceedsTheCourseCount(t *testing.T) {
+	defer swap(&maxInflight, 0)()
+	if got := inflightCap(6); got != 6 {
+		t.Errorf("uncapped with 6 courses = %d, want 6", got)
+	}
+	swap(&maxInflight, 99)
+	if got := inflightCap(6); got != 6 {
+		t.Errorf("cap of 99 with 6 courses = %d, want 6", got)
+	}
+	swap(&maxInflight, 2)
+	if got := inflightCap(6); got != 2 {
+		t.Errorf("cap of 2 with 6 courses = %d, want 2", got)
+	}
+}
+
 func TestFireWindowKeepsTheGapWhenAnswersAreInstant(t *testing.T) {
 	p := &portal{delay: 0, registered: map[string]bool{}}
 	srv := httptest.NewServer(p)

--- a/cmd/sniper/sniper_test.go
+++ b/cmd/sniper/sniper_test.go
@@ -377,6 +377,37 @@ func TestApplyCodeTimingRejectionKeepsThePlace(t *testing.T) {
 	}
 }
 
+// TestTimingRejectionIsOnlyFreeOnce: a partial window, where the portal keeps
+// refusing one course on timing grounds while the others get real verdicts.
+// After its free first rejection the refused course has to count like any
+// other, or it sits at judged 0 and takes the token ahead of every course that
+// can still land, every time it comes off cooldown, for the rest of the run.
+func TestTimingRejectionIsOnlyFreeOnce(t *testing.T) {
+	courses := mkCourses("40760-1", "40634-1")
+	refused, judged := courses[0], courses[1]
+	now := time.Now()
+
+	applyCode(newTestUI(), refused, 1, "REGISTRATION_TIME_LIMIT", 0)
+	applyCode(newTestUI(), judged, 1, "CAPACITY_EXCEEDED", 0)
+	if pick, _ := choose(courses, now); pick != refused {
+		t.Fatalf("after one timing rejection pick = %s, want the refused course to keep its place", pick.id)
+	}
+
+	applyCode(newTestUI(), refused, 2, "REGISTRATION_TIME_LIMIT", 0)
+	if refused.judged != 1 {
+		t.Fatalf("judged = %d after a second timing rejection, want 1", refused.judged)
+	}
+	if refused.parked || refused.done {
+		t.Fatalf("parked=%t done=%t, a timing code is neither permanent nor a success", refused.parked, refused.done)
+	}
+	// Both are now judged once, so list order decides again, and a third
+	// rejection puts the refused course behind the one with a real verdict.
+	applyCode(newTestUI(), refused, 3, "REGISTRATION_TIME_LIMIT", 0)
+	if pick, _ := choose(courses, now); pick != judged {
+		t.Fatalf("after three timing rejections pick = %s, want the course with a real verdict", pick.id)
+	}
+}
+
 func TestPostTurnsAnErrorFieldIntoAResult(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, `{"error":"TOO_MANY_REQUESTS"}`)

--- a/cmd/sniper/sniper_test.go
+++ b/cmd/sniper/sniper_test.go
@@ -310,6 +310,118 @@ func TestPostReportsRateLimiting(t *testing.T) {
 	}
 }
 
+// TestApplyJobsReadsTheNewestJobEvenBeforeItIsJudged pins the run A shape of
+// 2026-09-08: the course's own job is still queued, and an older job for the
+// same course carries a stale verdict. The stale one must not be read.
+func TestApplyJobsReadsTheNewestJobEvenBeforeItIsJudged(t *testing.T) {
+	courses := mkCourses("37514-2", "40416-1")
+	pick := courses[0]
+	pick.next = time.Now().Add(courseCooldown)
+	resp := &regResponse{Jobs: []job{
+		{CourseID: "37514-2", Result: ""},              // this attempt, not judged yet
+		{CourseID: "37514-2", Result: "CLASS_OVERLAP"}, // an earlier attempt
+		{CourseID: "40416-1", Result: resultOK},
+	}}
+	applyJobs(newTestUI(), courses, pick, 1, resp, 0)
+
+	if pick.last != "QUEUED" {
+		t.Fatalf("last = %q, want QUEUED, the stale verdict was read instead", pick.last)
+	}
+	if pick.parked {
+		t.Fatal("a stale CLASS_OVERLAP parked a course whose real job is still queued")
+	}
+	if pick.judged != 1 {
+		t.Fatalf("judged = %d, want 1, the backend did see the request", pick.judged)
+	}
+	if !courses[1].done {
+		t.Fatal("an OK for another course was not harvested")
+	}
+}
+
+// TestFireTimeDoesNotAddTheProbeRoundTrip: the probe runs on a cold
+// connection, so its round trip includes a TLS handshake that the request at
+// the window will never pay. Sending at recv + (window - server) already lands
+// a network round trip late, and only the fixed 100ms goes on top.
+func TestFireTimeDoesNotAddTheProbeRoundTrip(t *testing.T) {
+	recv := time.Date(2026, 9, 8, 7, 53, 13, 153e6, time.Local)
+	s := &clockSync{
+		recv:   recv,
+		rtt:    582 * time.Millisecond,
+		server: recv.Add(541 * time.Millisecond),
+	}
+	window := time.Date(2026, 9, 8, 8, 0, 0, 0, time.Local)
+	got := s.fireTime(window)
+	want := recv.Add(window.Sub(s.server) + 100*time.Millisecond)
+	if !got.Equal(want) {
+		t.Fatalf("fireTime = %s, want %s", got.Format("15:04:05.000"), want.Format("15:04:05.000"))
+	}
+	// The local clock is 541ms behind the server, so add that to read the
+	// fire time on the server's clock.
+	if late := got.Add(541 * time.Millisecond).Sub(window); late != 100*time.Millisecond {
+		t.Fatalf("fires %s after the window by the server's clock, want 100ms", late)
+	}
+}
+
+func TestApplyCodeTimingRejectionKeepsThePlace(t *testing.T) {
+	c := &course{id: "30004-1", next: time.Now().Add(courseCooldown)}
+	applyCode(newTestUI(), c, 1, "NO_REGISTRATION_TIME", 0)
+	if c.judged != 0 || c.parked || c.done {
+		t.Fatalf("judged=%d parked=%t done=%t after NO_REGISTRATION_TIME, want 0 false false", c.judged, c.parked, c.done)
+	}
+	if c.last != "NO_REGISTRATION_TIME" {
+		t.Fatalf("last = %q, want the code recorded", c.last)
+	}
+	applyCode(newTestUI(), c, 2, "CAPACITY_EXCEEDED", 0)
+	if c.judged != 1 {
+		t.Fatalf("judged = %d after a real verdict, want 1", c.judged)
+	}
+}
+
+func TestPostTurnsAnErrorFieldIntoAResult(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"error":"TOO_MANY_REQUESTS"}`)
+	}))
+	defer srv.Close()
+	defer swap(&regEndpoint, srv.URL)()
+
+	cl := &client{http: &http.Client{Timeout: time.Second}}
+	_, _, err := cl.add(&course{id: "30004-1", units: 1})
+
+	var str *stringResult
+	if !errors.As(err, &str) {
+		t.Fatalf("err = %v, want a stringResult", err)
+	}
+	if str.code != "TOO_MANY_REQUESTS" {
+		t.Errorf("code = %q, want TOO_MANY_REQUESTS", str.code)
+	}
+	if holdResults[str.code].hold == 0 {
+		t.Errorf("TOO_MANY_REQUESTS does not hold the shared token")
+	}
+}
+
+// TestWarmUpDoesNotHoldTheWindow: the warm up GET is sent and forgotten. A
+// portal that sits on it must not delay the first real request, and the token
+// still counts from the moment it went out.
+func TestWarmUpDoesNotHoldTheWindow(t *testing.T) {
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-release
+	}))
+	defer srv.Close()
+	defer close(release) // runs before srv.Close, which waits for handlers
+	defer swap(&portalOrigin, srv.URL)()
+
+	cl := &client{http: &http.Client{Timeout: 5 * time.Second}}
+	before := time.Now()
+	cl.warmUp(newTestUI(), before.Add(50*time.Millisecond))
+	if took := time.Since(before); took > 500*time.Millisecond {
+		t.Fatalf("warmUp blocked for %s waiting on an answer that never came", took)
+	}
+	if called := cl.called(); called.Before(before) {
+		t.Fatalf("the token does not count from the warm up: last call %s, warm up at %s", called, before)
+	}
+}
+
 func swap[T any](p *T, v T) func() {
 	old := *p
 	*p = v

--- a/docs/reference/error-codes.md
+++ b/docs/reference/error-codes.md
@@ -41,8 +41,12 @@ explanation so they are obvious at a glance.
 Two groups in the third column get special handling. The timing codes,
 `NO_REGISTRATION_TIME`, `REGISTRATION_TIME_LIMIT`, `NOT_LOGIN_TIME`,
 `LOGIN_TIME_RESTRICTION`, `EDU_TIME` and `CLOSED_INTERVAL`, mean the backend
-refused to look at the course, so they are not counted as verdicts and the
-course keeps its place in the order. `TOO_MANY_REQUESTS`, `PLEASE_WAIT` and
+refused to look at the course. The first one a course gets is not counted as a
+verdict, so an opening request that lands a moment early does not push the
+most contested course to the back of the list. Any further one counts like
+any other retryable result, otherwise a course the portal keeps refusing on
+timing grounds would outrank every course with a real verdict for the rest of
+the run. `TOO_MANY_REQUESTS`, `PLEASE_WAIT` and
 `BLOCKED` are the portal pushing back on the client as a whole, so they hold
 the shared request token the way a `429` does, for 2 seconds, or 30 seconds
 for `BLOCKED`, whose own text says minutes and which follows the student id

--- a/docs/reference/error-codes.md
+++ b/docs/reference/error-codes.md
@@ -38,6 +38,17 @@ course took nine attempts and roughly twenty eight seconds of scheduler time
 under the old rule. Permanent failures are called out in the log with a plain
 explanation so they are obvious at a glance.
 
+Two groups in the third column get special handling. The timing codes,
+`NO_REGISTRATION_TIME`, `REGISTRATION_TIME_LIMIT`, `NOT_LOGIN_TIME`,
+`LOGIN_TIME_RESTRICTION`, `EDU_TIME` and `CLOSED_INTERVAL`, mean the backend
+refused to look at the course, so they are not counted as verdicts and the
+course keeps its place in the order. `TOO_MANY_REQUESTS`, `PLEASE_WAIT` and
+`BLOCKED` are the portal pushing back on the client as a whole, so they hold
+the shared request token the way a `429` does, for 2 seconds, or 30 seconds
+for `BLOCKED`, whose own text says minutes and which follows the student id
+rather than the connection. An `error` field on an object body is read as a
+result code the same way a bare string body is.
+
 ---
 
 ## Full reference

--- a/docs/reference/rate-limits.md
+++ b/docs/reference/rate-limits.md
@@ -41,9 +41,18 @@ Both of run B's timeouts had in fact registered the course. A request that
 gives up client side may still have been carried out, so the answer to a
 timeout is to let the next response tell you, not to resend.
 
+Run A's rejections look inconsistent at first: a request sent 1.101s after the
+previous one was rejected and one sent 1.102s after was accepted. The
+difference is the connection. The request before the rejected one went out on
+a fresh connection and paid a TLS handshake inside its 818ms round trip, so it
+reached the edge several hundred milliseconds after the scheduler sent it and
+the next request followed it there well under a second later. The accepted
+pair were both on a warm connection. Spacing has to be measured from when the
+request is written, which is what the client now does.
+
 Run B also took a second `429` at 08:00:35, a full 5 seconds after its previous
 request and in the same millisecond as the answer to it. Nothing the sniper
-sent explains that. The limiter is keyed on the IP, so the traffic came from
+sent explains that, and it is the one observation no per client model covers. The limiter is keyed on the IP, so the traffic came from
 alongside it: a click in the browser, or another student behind the same NAT.
 The scheduler now treats a `429` as a 2 second hold on the shared token with
 the course keeping its place, which is the right response either way, but a
@@ -83,11 +92,15 @@ that matter.
 | **1.10s** | **12 / 14** | the gap `globalGap` currently uses |
 | 1.30s | 14 / 14 | clean across the whole run |
 
-The underlying limit really is one request per second, as the README says. The
-losses at 1.05s and 1.10s are not a different limit, they are jitter: measured
-round trip time on the same pooled connection ranged from 46ms to 2037ms in a
-single run, so a client gap of 1.10s regularly lands two requests less than a
-second apart at the edge.
+Everything here fits a limit of about one request per second, counted when
+the request arrives at the edge, with the losses at 1.05s and 1.10s being
+jitter: measured round trip time on the same pooled connection ranged from
+46ms to 2037ms in a single run, so a client gap of 1.10s can land two requests
+less than a second apart at the edge. But fitting is not proving. The samples
+are small, 1.2s and 1.5s both passed 10 of 12 where a hard threshold would
+show a step, and 12 of 14 against 14 of 14 is not a significant difference on
+its own. Treat "one per second" as the working model and 1.3s as the working
+default, not as a measured rule.
 
 ### Consequence for `globalGap`
 

--- a/docs/reference/rate-limits.md
+++ b/docs/reference/rate-limits.md
@@ -41,6 +41,20 @@ Both of run B's timeouts had in fact registered the course. A request that
 gives up client side may still have been carried out, so the answer to a
 timeout is to let the next response tell you, not to resend.
 
+Run B also took a second `429` at 08:00:35, a full 5 seconds after its previous
+request and in the same millisecond as the answer to it. Nothing the sniper
+sent explains that. The limiter is keyed on the IP, so the traffic came from
+alongside it: a click in the browser, or another student behind the same NAT.
+The scheduler now treats a `429` as a 2 second hold on the shared token with
+the course keeping its place, which is the right response either way, but a
+browser tab on the portal during the window is a cost you can avoid.
+
+Both runs also got `REPEATED_REQUEST` on a course that then landed from a job
+the sniper had not knowingly queued. The job ids sit where a request sent a
+second or two before the sniper's would sit, which again points at a click in
+the browser, and it is why `REPEATED_REQUEST` is now read as "the portal has
+it" rather than as a failure.
+
 ---
 
 ## 1. The edge limiter on `/api/reg`

--- a/docs/reference/rate-limits.md
+++ b/docs/reference/rate-limits.md
@@ -158,9 +158,11 @@ expensive. The frontend ships user facing strings for all of it:
 
 `BLOCKED` is keyed on the **student ID**, so unlike the edge limiter it follows
 you across networks and cannot be escaped by reconnecting. `TOO_MANY_REQUESTS`
-is a concurrency guard, which is why the scheduler still sends on a single
-global token and only lets a few answers be outstanding at once. Neither code
-has been seen live. If one shows up, lower `-inflight`.
+is a concurrency guard. The scheduler still sends on a single global token, so
+it never exceeds one request per gap however many answers are outstanding, and
+the number outstanding is capped anyway at one per course. Neither code has been
+seen live. If one shows up, `-inflight` sets a hard cap and `-inflight 1`
+restores serial behaviour.
 
 ---
 

--- a/docs/reference/server-contract.md
+++ b/docs/reference/server-contract.md
@@ -11,7 +11,7 @@ This is the summary. The rest of this directory is the detail behind it:
 
 | Measured behaviour | Consequence for the client |
 | --- | --- |
-| The edge allows **exactly one request per second, with no burst**, and rejects the rest with a real HTTP `429` and an HTML body. | A parallel burst throws most of its requests away. Pacing is the single most important thing the client does. |
+| The edge rejects a request that follows the previous one too closely with a real HTTP `429` and an HTML body. Every measurement fits **about one request per second, no burst**, but none proves it. | A parallel burst throws most of its requests away. Pacing is the single most important thing the client does, and the gap is a working default, not a measured threshold. |
 | **Every** request to the host counts, including a plain `GET /`. | Connection warm up must happen well before the window, never immediately before it. |
 | Application errors arrive as **HTTP 200** with an `error` field in the JSON body. | Status codes cannot be used to detect failure, apart from `429`. |
 | Auth failure is `{"error":"AUTHORIZATION"}`, never a `401`. | The token check has to read the body. |
@@ -38,7 +38,7 @@ time and server time agree.
 
 | Row | Detail |
 | --- | --- |
-| one request per second, `429` on the rest | [rate-limits.md](rate-limits.md), including a re-measurement on a warm pooled connection |
+| about one request per second, `429` on the rest | [rate-limits.md](rate-limits.md), including a re-measurement on a warm pooled connection and what the live window did not settle |
 | every request counts, including `GET /` | [rate-limits.md](rate-limits.md#2-which-requests-count-and-which-get-rejected), where counting and rejection turn out to be different sets |
 | errors arrive as HTTP 200 | [http-api.md](http-api.md#conventions) |
 | auth failure is a body, not a `401` | [auth.md](auth.md) |

--- a/tools/limits/main.go
+++ b/tools/limits/main.go
@@ -1,0 +1,791 @@
+// Command limits measures what the portal's edge actually rejects.
+//
+// The sniper's pacing rests on a claim that has never been tested properly:
+// that /api/reg allows one request per second. Two live transcripts contradict
+// it. On 2026-09-08 a request sent 1.101s after the previous one was rejected
+// while one sent 1.102s after passed, and a request sent 5.077s after the
+// previous one was rejected anyway. The tables the constants came from do not
+// settle it either: 1.2s and 1.5s both passed 10 of 12, and the 12 of 14
+// against 14 of 14 that moved globalGap to 1.3s is a two-sided Fisher exact
+// p of 0.48, which is noise.
+//
+// This tool answers three questions the transcripts cannot.
+//
+//  1. Does the gap between requests change the rejection rate at all, or is
+//     rejection independent of how you space them?
+//  2. Is there a burst allowance? The portal negotiates HTTP/2, so every
+//     request multiplexes onto one connection, and whether k at once are
+//     accepted matters far more to a sniper than spacing does.
+//  3. Is rejection driven by your own pattern or by load on the portal? Run
+//     the same schedule at a quiet hour and again near a busy one and compare.
+//
+// # Why this is safe to run
+//
+// The 429 body is nginx's own HTML, so rejection happens at the edge, before
+// Express and therefore before authentication. That means the limiter can be
+// measured with a deliberately invalid token: the request never establishes a
+// student id, so no job is queued, no registration action is spent, and
+// BLOCKED, which is keyed on the student id, cannot be tripped. The course id
+// is one that cannot exist, so even a misconfigured run has nothing to act on.
+//
+// That the edge behaves identically for an invalid token is the one assumption
+// this rests on. Check it with -verify-with-token once, which sends a small
+// paired sample with a real token and compares the two rejection rates.
+//
+// The tool refuses to run near a registration window, holds a ceiling on total
+// requests, and stops immediately if the portal ever answers BLOCKED or
+// TOO_MANY_REQUESTS.
+//
+// # Use
+//
+//	limits -mode spacing -n 40 -out spacing.csv
+//	limits -mode burst -sizes 1,2,3,5,8 -reps 8 -out burst.csv
+//
+// Read the summary, then read the CSV. Two rates differ only if their
+// intervals do not overlap. On a shared campus NAT you are measuring a budget
+// you share with everyone else on it, which is worth recording alongside.
+package main
+
+import (
+	"bytes"
+	gocontext "context"
+	"crypto/tls"
+	"encoding/csv"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"math"
+	"math/rand"
+	"net/http"
+	"net/http/httptrace"
+	"os"
+	"os/signal"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+)
+
+const (
+	defaultTarget = "https://my.edu.sharif.edu/api/reg"
+	// probeCourse cannot exist, so no run of this tool can register anything
+	// even if a real token is handed to it by mistake.
+	probeCourse = "00000-0"
+	// invalidToken is syntactically a JWT and verifies against nothing.
+	invalidToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdHVkZW50SWQiOiJub3QtYS1zdHVkZW50In0.not-a-signature"
+	// hardCeiling is the most requests any single run may send, whatever the
+	// flags say. A measurement is not worth more traffic than this.
+	hardCeiling = 1200
+)
+
+// windows are the registration hours the sniper knows about. Measuring near
+// one risks both a useless number, since the portal is under load, and a
+// rate limit state that follows you into the window itself.
+var windows = []string{"08:00", "16:00"}
+
+const (
+	windowLeadOut  = 90 * time.Minute
+	windowTrailing = 30 * time.Minute
+)
+
+type trial struct {
+	mode      string
+	seq       int
+	wantGap   time.Duration // the gap this trial was scheduled with
+	burstSize int           // burst mode only
+	sentAt    time.Time
+	sinceRel  time.Duration // from the start of the run
+	realGap   time.Duration // measured gap since the previous send
+	status    int
+	rtt       time.Duration
+	ttfb      time.Duration
+	proto     string
+	reused    bool
+	code      string // portal error code when the body carried one
+	retryHdr  string
+	rlRemain  string
+	err       string
+}
+
+func (t trial) rejected() bool { return t.status == http.StatusTooManyRequests }
+
+func main() { os.Exit(run()) }
+
+func run() int {
+	var (
+		fURL       = flag.String("url", defaultTarget, "endpoint to probe")
+		fMode      = flag.String("mode", "spacing", "spacing or burst")
+		fIntervals = flag.String("intervals", "0.2,0.5,0.8,1.1,1.4,2.0,3.0", "spacing mode: gaps in seconds")
+		fN         = flag.Int("n", 40, "spacing mode: samples per gap")
+		fSizes     = flag.String("sizes", "1,2,3,5,8", "burst mode: how many at once")
+		fReps      = flag.Int("reps", 8, "burst mode: bursts per size")
+		fCool      = flag.Duration("cool", 15*time.Second, "burst mode: quiet time between bursts")
+		fOut       = flag.String("out", "", "write the trials to this CSV")
+		fToken     = flag.String("verify-with-token", "", "also run a small paired sample with this real token, to check the edge treats both alike")
+		fYes       = flag.Bool("y", false, "skip the confirmation prompt")
+		fForce     = flag.Bool("force", false, "run even near a registration window")
+	)
+	flag.Parse()
+
+	if why, near := nearWindow(time.Now()); near && !*fForce {
+		fmt.Fprintf(os.Stderr, "refusing to run: %s\n", why)
+		fmt.Fprintf(os.Stderr, "measuring under window load tells you about the load, not the limiter.\n")
+		fmt.Fprintf(os.Stderr, "pass -force if you really mean it.\n")
+		return 2
+	}
+
+	plan, err := buildPlan(*fMode, *fIntervals, *fN, *fSizes, *fReps, *fCool)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 2
+	}
+	if plan.requests > hardCeiling {
+		fmt.Fprintf(os.Stderr, "refusing to send %d requests, the ceiling is %d. lower -n or -reps.\n",
+			plan.requests, hardCeiling)
+		return 2
+	}
+
+	fmt.Printf("target       %s\n", *fURL)
+	fmt.Printf("mode         %s\n", plan.mode)
+	fmt.Printf("requests     %d\n", plan.requests)
+	fmt.Printf("estimated    %s\n", plan.duration.Round(time.Second))
+	fmt.Printf("token        invalid on purpose, so nothing is queued against your account\n")
+	fmt.Printf("course       %s, which cannot exist\n", probeCourse)
+	if !*fYes && !confirm() {
+		return 2
+	}
+
+	ctx, stop := signal.NotifyContext(gocontext.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	p := &prober{url: *fURL, client: newClient()}
+	p.warm()
+
+	var trials []trial
+	switch plan.mode {
+	case "spacing":
+		trials = p.spacing(ctx, plan)
+	case "burst":
+		trials = p.burst(ctx, plan)
+	}
+
+	if *fToken != "" {
+		fmt.Printf("\n== paired check against a real token ===========================\n")
+		fmt.Printf("  this one does reach Express, so it queues jobs for %s.\n", probeCourse)
+		trials = append(trials, p.paired(ctx, *fToken)...)
+	}
+
+	if *fOut != "" {
+		if err := writeCSV(*fOut, trials); err != nil {
+			fmt.Fprintf(os.Stderr, "csv: %v\n", err)
+		} else {
+			fmt.Printf("\nwrote %d trials to %s\n", len(trials), *fOut)
+		}
+	}
+	report(plan.mode, trials)
+	return 0
+}
+
+// ------------------------------------------------------------------- planning
+
+type plan struct {
+	mode     string
+	gaps     []time.Duration // spacing mode, already shuffled
+	sizes    []int           // burst mode
+	reps     int
+	cool     time.Duration
+	requests int
+	duration time.Duration
+}
+
+// buildPlan lays out the trials. In spacing mode the gaps are shuffled rather
+// than run in blocks, so that drift in portal load over the run cannot line up
+// with any one gap and masquerade as an effect of it. Each response is
+// attributed to the gap that preceded it.
+func buildPlan(mode, intervals string, n int, sizes string, reps int, cool time.Duration) (plan, error) {
+	switch mode {
+	case "spacing":
+		vals, err := parseSeconds(intervals)
+		if err != nil {
+			return plan{}, err
+		}
+		if n < 1 {
+			return plan{}, errors.New("-n must be at least 1")
+		}
+		var gaps []time.Duration
+		var total time.Duration
+		for _, v := range vals {
+			for i := 0; i < n; i++ {
+				gaps = append(gaps, v)
+				total += v
+			}
+		}
+		rand.Shuffle(len(gaps), func(i, j int) { gaps[i], gaps[j] = gaps[j], gaps[i] })
+		return plan{mode: mode, gaps: gaps, requests: len(gaps), duration: total}, nil
+	case "burst":
+		vals, err := parseInts(sizes)
+		if err != nil {
+			return plan{}, err
+		}
+		if reps < 1 {
+			return plan{}, errors.New("-reps must be at least 1")
+		}
+		count := 0
+		for _, k := range vals {
+			count += k * reps
+		}
+		return plan{
+			mode: mode, sizes: vals, reps: reps, cool: cool,
+			requests: count,
+			duration: time.Duration(len(vals)*reps) * cool,
+		}, nil
+	}
+	return plan{}, fmt.Errorf("unknown mode %q, want spacing or burst", mode)
+}
+
+func parseSeconds(s string) ([]time.Duration, error) {
+	var out []time.Duration
+	for _, f := range strings.Split(s, ",") {
+		f = strings.TrimSpace(f)
+		if f == "" {
+			continue
+		}
+		v, err := strconv.ParseFloat(f, 64)
+		if err != nil || v < 0 {
+			return nil, fmt.Errorf("cannot read %q as seconds", f)
+		}
+		out = append(out, time.Duration(v*float64(time.Second)))
+	}
+	if len(out) == 0 {
+		return nil, errors.New("no intervals given")
+	}
+	return out, nil
+}
+
+func parseInts(s string) ([]int, error) {
+	var out []int
+	for _, f := range strings.Split(s, ",") {
+		f = strings.TrimSpace(f)
+		if f == "" {
+			continue
+		}
+		v, err := strconv.Atoi(f)
+		if err != nil || v < 1 {
+			return nil, fmt.Errorf("cannot read %q as a burst size", f)
+		}
+		out = append(out, v)
+	}
+	if len(out) == 0 {
+		return nil, errors.New("no sizes given")
+	}
+	return out, nil
+}
+
+// nearWindow reports whether now is close enough to a registration window that
+// a measurement would be about the load rather than about the limiter.
+func nearWindow(now time.Time) (string, bool) {
+	for _, w := range windows {
+		var h, m int
+		fmt.Sscanf(w, "%d:%d", &h, &m)
+		at := time.Date(now.Year(), now.Month(), now.Day(), h, m, 0, 0, now.Location())
+		if now.After(at.Add(-windowLeadOut)) && now.Before(at.Add(windowTrailing)) {
+			return fmt.Sprintf("it is %s, within %s of the %s window",
+				now.Format("15:04"), windowLeadOut, w), true
+		}
+	}
+	return "", false
+}
+
+func confirm() bool {
+	fmt.Print("\nstart? [y/N]: ")
+	var line string
+	fmt.Scanln(&line)
+	line = strings.ToLower(strings.TrimSpace(line))
+	return line == "y" || line == "yes"
+}
+
+// -------------------------------------------------------------------- probing
+
+type prober struct {
+	url    string
+	client *http.Client
+	seq    int
+	last   time.Time
+	start  time.Time
+	halted string // set when the portal told us to stop
+}
+
+// newClient shares one transport so HTTP/2 multiplexing is exercised the same
+// way the sniper exercises it. Without that, a burst would measure connection
+// setup rather than the limiter.
+func newClient() *http.Client {
+	tr := http.DefaultTransport.(*http.Transport).Clone()
+	tr.ForceAttemptHTTP2 = true
+	tr.MaxIdleConns = 64
+	tr.MaxIdleConnsPerHost = 64
+	return &http.Client{Transport: tr, Timeout: 15 * time.Second}
+}
+
+// warm opens the connection and then waits, so the first measured trial is not
+// paying a TLS handshake and the warm up's own request has left the counter.
+func (p *prober) warm() {
+	req, err := http.NewRequest(http.MethodGet, origin(p.url)+"/", nil)
+	if err != nil {
+		return
+	}
+	start := time.Now()
+	res, err := p.client.Do(req)
+	if err != nil {
+		fmt.Printf("warm up failed: %v\n", err)
+		return
+	}
+	io.Copy(io.Discard, res.Body)
+	res.Body.Close()
+	fmt.Printf("\nwarm up      %s in %dms, settling for 5s so it leaves the counter\n",
+		res.Proto, time.Since(start).Milliseconds())
+	time.Sleep(5 * time.Second)
+	p.start = time.Now()
+}
+
+func origin(u string) string {
+	if i := strings.Index(u, "://"); i >= 0 {
+		if j := strings.Index(u[i+3:], "/"); j >= 0 {
+			return u[:i+3+j]
+		}
+	}
+	return u
+}
+
+// spacing walks the shuffled schedule, sleeping the scheduled gap before each
+// request and recording the gap actually achieved alongside the outcome.
+func (p *prober) spacing(ctx ctxt, pl plan) []trial {
+	fmt.Printf("\n== spacing =====================================================\n")
+	out := make([]trial, 0, len(pl.gaps))
+	for i, gap := range pl.gaps {
+		if ctx.Err() != nil || p.halted != "" {
+			break
+		}
+		if i > 0 {
+			sleepUntil(ctx, p.last.Add(gap))
+		}
+		t := p.probe(invalidToken)
+		t.mode, t.wantGap = "spacing", gap
+		out = append(out, t)
+		p.progress(len(out), pl.requests, t)
+	}
+	return out
+}
+
+// burst fires k requests at the same instant and counts how many the edge
+// takes, which is the question a spacing test cannot answer.
+func (p *prober) burst(ctx ctxt, pl plan) []trial {
+	fmt.Printf("\n== burst =======================================================\n")
+	var out []trial
+	done := 0
+	for _, k := range pl.sizes {
+		for r := 0; r < pl.reps; r++ {
+			if ctx.Err() != nil || p.halted != "" {
+				return out
+			}
+			if done > 0 {
+				sleepUntil(ctx, time.Now().Add(pl.cool))
+			}
+			var (
+				wg    sync.WaitGroup
+				mu    sync.Mutex
+				batch []trial
+				gate  = make(chan struct{})
+			)
+			for j := 0; j < k; j++ {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					<-gate // release them together
+					t := p.probe(invalidToken)
+					t.mode, t.burstSize = "burst", k
+					mu.Lock()
+					batch = append(batch, t)
+					mu.Unlock()
+				}()
+			}
+			close(gate)
+			wg.Wait()
+
+			passed := 0
+			for _, t := range batch {
+				if !t.rejected() && t.err == "" {
+					passed++
+				}
+			}
+			out = append(out, batch...)
+			done++
+			fmt.Printf("  burst of %-2d  %d accepted, %d rejected\n", k, passed, k-passed)
+		}
+	}
+	return out
+}
+
+// paired alternates an invalid token with a real one at the same spacing, to
+// check the assumption the whole method rests on: that the edge rejects both
+// the same way, because it rejects before Express ever reads the token.
+func (p *prober) paired(ctx ctxt, token string) []trial {
+	var out []trial
+	for i := 0; i < 24; i++ {
+		if ctx.Err() != nil || p.halted != "" {
+			break
+		}
+		sleepUntil(ctx, p.last.Add(600*time.Millisecond))
+		tok, label := invalidToken, "paired-invalid"
+		if i%2 == 1 {
+			tok, label = token, "paired-real"
+		}
+		t := p.probe(tok)
+		t.mode, t.wantGap = label, 600*time.Millisecond
+		out = append(out, t)
+	}
+	inv, real_ := split(out, "paired-invalid")
+	li, hi := wilson(rejects(inv), len(inv))
+	lr, hr := wilson(rejects(real_), len(real_))
+	fmt.Printf("  invalid token  %d of %d rejected, 95%% interval %.0f%% to %.0f%%\n",
+		rejects(inv), len(inv), li*100, hi*100)
+	fmt.Printf("  real token     %d of %d rejected, 95%% interval %.0f%% to %.0f%%\n",
+		rejects(real_), len(real_), lr*100, hr*100)
+	if overlap(li, hi, lr, hr) {
+		fmt.Printf("  the intervals overlap, so the invalid token is a fair stand in\n")
+	} else {
+		fmt.Printf("  THE INTERVALS DO NOT OVERLAP. the edge treats them differently,\n")
+		fmt.Printf("  so the main results are not safe to read as being about a real client.\n")
+	}
+	return out
+}
+
+func (p *prober) probe(token string) trial {
+	p.seq++
+	t := trial{seq: p.seq}
+
+	body := fmt.Sprintf(`{"action":"add","course":%q,"units":0}`, probeCourse)
+	req, err := http.NewRequest(http.MethodPost, p.url, bytes.NewReader([]byte(body)))
+	if err != nil {
+		t.err = err.Error()
+		return t
+	}
+	req.Header.Set("Authorization", token)
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Origin", origin(p.url))
+	req.Header.Set("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/151.0.0.0 Safari/537.36")
+
+	var start time.Time
+	req = req.WithContext(httptrace.WithClientTrace(req.Context(), &httptrace.ClientTrace{
+		GotConn:              func(i httptrace.GotConnInfo) { t.reused = i.Reused },
+		GotFirstResponseByte: func() { t.ttfb = time.Since(start) },
+		TLSHandshakeDone:     func(tls.ConnectionState, error) {},
+	}))
+
+	start = time.Now()
+	t.sentAt = start
+	if !p.start.IsZero() {
+		t.sinceRel = start.Sub(p.start)
+	}
+	if !p.last.IsZero() {
+		t.realGap = start.Sub(p.last)
+	}
+	p.last = start
+
+	res, err := p.client.Do(req)
+	t.rtt = time.Since(start)
+	if err != nil {
+		t.err = err.Error()
+		return t
+	}
+	defer res.Body.Close()
+	raw, _ := io.ReadAll(io.LimitReader(res.Body, 4<<10))
+
+	t.status = res.StatusCode
+	t.proto = res.Proto
+	t.retryHdr = res.Header.Get("Retry-After")
+	t.rlRemain = res.Header.Get("X-RateLimit-Remaining")
+	t.code = codeOf(raw)
+
+	// The portal telling us to stop is the one result worth aborting on.
+	if t.code == "BLOCKED" || t.code == "TOO_MANY_REQUESTS" {
+		p.halted = t.code
+		fmt.Printf("\nSTOPPING: the portal answered %s. that is the application level\n", t.code)
+		fmt.Printf("guard, not the edge. no further requests will be sent.\n")
+	}
+	return t
+}
+
+// codeOf pulls the portal's error code out of a body, whether it arrived as an
+// object with an error field or as the bare quoted string the portal also uses.
+func codeOf(raw []byte) string {
+	s := strings.TrimSpace(string(raw))
+	if s == "" || s[0] == '<' {
+		return ""
+	}
+	if i := strings.Index(s, `"error":"`); i >= 0 {
+		rest := s[i+9:]
+		if j := strings.IndexByte(rest, '"'); j >= 0 {
+			return rest[:j]
+		}
+	}
+	if s[0] == '"' {
+		s = strings.Trim(s, `"`)
+		if i := strings.IndexByte(s, ' '); i >= 0 {
+			return s[:i]
+		}
+		return s
+	}
+	return ""
+}
+
+func (p *prober) progress(done, total int, t trial) {
+	if done%10 != 0 && !t.rejected() && t.err == "" {
+		return
+	}
+	what := strconv.Itoa(t.status)
+	if t.err != "" {
+		what = "error"
+	}
+	if t.rejected() {
+		what = "429 REJECTED"
+	}
+	fmt.Printf("  %3d/%d  gap %5.2fs  %s\n", done, total, t.realGap.Seconds(), what)
+}
+
+// ------------------------------------------------------------------ reporting
+
+func report(mode string, trials []trial) {
+	if len(trials) == 0 {
+		fmt.Println("\nno trials completed")
+		return
+	}
+	fmt.Printf("\n== result ======================================================\n")
+
+	switch mode {
+	case "spacing":
+		reportSpacing(trials)
+	case "burst":
+		reportBurst(trials)
+	}
+	reportOverTime(trials)
+}
+
+func reportSpacing(trials []trial) {
+	byGap := map[time.Duration][]trial{}
+	for _, t := range trials {
+		if t.mode != "spacing" {
+			continue
+		}
+		byGap[t.wantGap] = append(byGap[t.wantGap], t)
+	}
+	gaps := make([]time.Duration, 0, len(byGap))
+	for g := range byGap {
+		gaps = append(gaps, g)
+	}
+	sort.Slice(gaps, func(i, j int) bool { return gaps[i] < gaps[j] })
+
+	fmt.Printf("  gap      n    rejected   rate    95%% interval\n")
+	var los, his []float64
+	for _, g := range gaps {
+		ts := byGap[g]
+		k := rejects(ts)
+		lo, hi := wilson(k, len(ts))
+		los, his = append(los, lo), append(his, hi)
+		fmt.Printf("  %5.2fs  %-4d %-10d %5.1f%%  %4.1f%% to %4.1f%%\n",
+			g.Seconds(), len(ts), k, float64(k)/float64(len(ts))*100, lo*100, hi*100)
+	}
+
+	// The question is whether any two gaps differ by more than noise.
+	separated := false
+	for i := range gaps {
+		for j := i + 1; j < len(gaps); j++ {
+			if !overlap(los[i], his[i], los[j], his[j]) {
+				separated = true
+				fmt.Printf("\n  %.2fs and %.2fs do not overlap: spacing changes the outcome there.\n",
+					gaps[i].Seconds(), gaps[j].Seconds())
+			}
+		}
+	}
+	if !separated {
+		fmt.Printf("\n  every interval overlaps every other one. at this sample size the\n")
+		fmt.Printf("  data does not show spacing affecting rejection at all. either the\n")
+		fmt.Printf("  effect is smaller than %d samples per gap can see, or it is not there.\n",
+			len(byGap[gaps[0]]))
+	}
+}
+
+func reportBurst(trials []trial) {
+	bySize := map[int][]trial{}
+	for _, t := range trials {
+		if t.mode != "burst" {
+			continue
+		}
+		bySize[t.burstSize] = append(bySize[t.burstSize], t)
+	}
+	sizes := make([]int, 0, len(bySize))
+	for k := range bySize {
+		sizes = append(sizes, k)
+	}
+	sort.Ints(sizes)
+
+	fmt.Printf("  at once   requests   rejected   rate    95%% interval\n")
+	for _, k := range sizes {
+		ts := bySize[k]
+		r := rejects(ts)
+		lo, hi := wilson(r, len(ts))
+		fmt.Printf("  %-9d %-10d %-10d %5.1f%%  %4.1f%% to %4.1f%%\n",
+			k, len(ts), r, float64(r)/float64(len(ts))*100, lo*100, hi*100)
+	}
+	fmt.Printf("\n  a burst allowance shows up as a flat rejection rate that only climbs\n")
+	fmt.Printf("  past some size. a strict one-at-a-time limiter rejects everything\n")
+	fmt.Printf("  beyond the first of every burst, so the rate would track 1 - 1/k.\n")
+}
+
+// reportOverTime is the load-shedding check. If rejections cluster in time
+// rather than spreading across the run, the cause is the portal's state, not
+// the pattern, and no amount of spacing will help.
+func reportOverTime(trials []trial) {
+	var first, last time.Duration
+	for _, t := range trials {
+		if t.sinceRel > last {
+			last = t.sinceRel
+		}
+	}
+	if last == 0 {
+		return
+	}
+	const buckets = 10
+	width := last / buckets
+	if width == 0 {
+		return
+	}
+	counts := make([]int, buckets+1)
+	totals := make([]int, buckets+1)
+	for _, t := range trials {
+		b := int(t.sinceRel / width)
+		if b > buckets {
+			b = buckets
+		}
+		totals[b]++
+		if t.rejected() {
+			counts[b]++
+		}
+	}
+	fmt.Printf("\n  rejections over the run, %s per bucket:\n", width.Round(time.Second))
+	any := false
+	for i := 0; i <= buckets; i++ {
+		if totals[i] == 0 {
+			continue
+		}
+		bar := strings.Repeat("#", counts[i])
+		if counts[i] > 0 {
+			any = true
+		}
+		fmt.Printf("    +%-6s %2d/%-3d %s\n",
+			(time.Duration(i) * width).Round(time.Second), counts[i], totals[i], bar)
+	}
+	_ = first
+	if !any {
+		fmt.Printf("    none. the edge did not reject a single request in this run.\n")
+	}
+}
+
+func rejects(ts []trial) int {
+	n := 0
+	for _, t := range ts {
+		if t.rejected() {
+			n++
+		}
+	}
+	return n
+}
+
+func split(ts []trial, mode string) (match, other []trial) {
+	for _, t := range ts {
+		if t.mode == mode {
+			match = append(match, t)
+		} else {
+			other = append(other, t)
+		}
+	}
+	return
+}
+
+// wilson is the score interval for a binomial proportion. It is used rather
+// than the normal approximation because the interesting cases here are zero
+// rejections out of n, where the normal interval collapses to a point and
+// invites exactly the overconfidence that produced the 1.3s gap.
+func wilson(k, n int) (float64, float64) {
+	if n == 0 {
+		return 0, 1
+	}
+	const z = 1.959963985
+	p := float64(k) / float64(n)
+	fn := float64(n)
+	den := 1 + z*z/fn
+	centre := (p + z*z/(2*fn)) / den
+	margin := z * math.Sqrt(p*(1-p)/fn+z*z/(4*fn*fn)) / den
+	lo, hi := centre-margin, centre+margin
+	if lo < 0 {
+		lo = 0
+	}
+	if hi > 1 {
+		hi = 1
+	}
+	return lo, hi
+}
+
+func overlap(lo1, hi1, lo2, hi2 float64) bool { return lo1 <= hi2 && lo2 <= hi1 }
+
+func writeCSV(path string, trials []trial) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	w := csv.NewWriter(f)
+	defer w.Flush()
+	if err := w.Write([]string{
+		"seq", "mode", "sent_at", "since_start_s", "scheduled_gap_s", "actual_gap_s",
+		"burst_size", "status", "rejected", "rtt_ms", "ttfb_ms", "proto", "conn_reused",
+		"portal_code", "retry_after", "ratelimit_remaining", "error",
+	}); err != nil {
+		return err
+	}
+	for _, t := range trials {
+		if err := w.Write([]string{
+			strconv.Itoa(t.seq), t.mode, t.sentAt.Format(time.RFC3339Nano),
+			fmt.Sprintf("%.3f", t.sinceRel.Seconds()),
+			fmt.Sprintf("%.3f", t.wantGap.Seconds()),
+			fmt.Sprintf("%.3f", t.realGap.Seconds()),
+			strconv.Itoa(t.burstSize), strconv.Itoa(t.status),
+			strconv.FormatBool(t.rejected()),
+			strconv.FormatInt(t.rtt.Milliseconds(), 10),
+			strconv.FormatInt(t.ttfb.Milliseconds(), 10),
+			t.proto, strconv.FormatBool(t.reused),
+			t.code, t.retryHdr, t.rlRemain, t.err,
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type ctxt = gocontext.Context
+
+func sleepUntil(ctx ctxt, at time.Time) {
+	d := time.Until(at)
+	if d <= 0 {
+		return
+	}
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-t.C:
+	case <-ctx.Done():
+	}
+}


### PR DESCRIPTION
## What this changes

Adds `tools/limits`, a standard library Go program that measures the rejection
behaviour of `/api/reg` instead of assuming it. No change to `cmd/sniper`.

## Why

The pacing rests on a claim no measurement supports. Both transcripts from
2026-09-08 contradict a one-request-per-second rule:

| | run | gap since previous send | outcome |
| --- | --- | --- | --- |
| #4 | A | 1.101s | **429** |
| #6 | A | 1.102s | 200 |
| #8 | B | 5.077s | **429** |
| #7 to #29 | A | 2.0s to 3.7s, 23 requests | all 200 |

One millisecond of difference in spacing, opposite outcomes, and a rejection
five seconds after the previous request. The 2026-09-07 tables in
`docs/reference/rate-limits.md` do not settle it either: 1.2s and 1.5s both
passed 10 of 12, where a real threshold would show a step, and the 12/14
against 14/14 that moved `globalGap` to 1.3s gives a two-sided Fisher exact
**p = 0.48**. Fourteen clean requests only bound the rejection rate below 19%.

So the constants the scheduler is built on may be measuring noise. This settles
it rather than arguing about it.

## Why it is safe to run

The 429 body is nginx's own page, so rejection happens at the edge, before
Express and therefore before authentication. Probing with a deliberately
invalid token measures the same limiter without ever establishing a student id:
no job is queued, no registration action is spent, and `BLOCKED`, which is
keyed on the student id, cannot be tripped. The course id used cannot exist
either, so even a misconfigured run has nothing to act on.

That the edge treats both tokens alike is the one assumption the method rests
on, and `-verify-with-token` tests it directly by comparing paired samples and
saying plainly if the two intervals fail to overlap.

It also refuses to run within 90 minutes of a registration window, holds a hard
ceiling of 1200 requests per run, and stops on the first `BLOCKED` or
`TOO_MANY_REQUESTS`.

## Method

Spacings are **shuffled rather than run in blocks**, so drift in portal load
over a run cannot line up with one gap and masquerade as an effect of it. Each
response is attributed to the gap that preceded it.

Every rate is reported with a **Wilson interval**, chosen because the
interesting case here is zero rejections out of n, where the normal
approximation collapses to a point and invites exactly the overconfidence that
produced the 1.3s gap. Two rates are only called different when their intervals
do not overlap.

Burst mode fires k requests at one instant. Since the portal negotiates
HTTP/2, they multiplex onto a single connection, so this measures the limiter
rather than connection setup. Whether a burst allowance exists matters far more
to a sniper than spacing does.

A rejections-over-time histogram is printed for every run, because if
rejections cluster in time rather than spreading across a shuffled schedule,
the cause is the portal's state and no amount of spacing will help.

## How it was verified

Validated against three servers with known behaviour before being pointed at
anything real:

| stand-in server | what the tool reported |
| --- | --- |
| strict 1 request/second | 90% rejected at 0.3s, 0% at 1.5s, intervals separated |
| no limiter at all | 0% at both, and said 10 samples only bound the rate below 28% |
| token bucket, depth 3, refill 1/s | bursts of 1, 2, 3 accepted; 5 and 8 rejected at rates matching depth 3 |

The third is the important one: it recovers a burst allowance and its depth,
which is the question the transcripts cannot answer.

`gofmt`, `go vet ./...`, `go build ./...` and `go test ./...` are clean. Not
yet run against the live portal, which is the next step and needs to happen at
a quiet hour.

## Suggested first run

```
limits -mode spacing -n 40 -out spacing.csv
limits -mode burst -sizes 1,2,3,5,8 -reps 8 -out burst.csv
```

Then repeat both near a busy hour. If the rejection rate tracks the clock
rather than the spacing, the cause is load shedding, the strategy is backwards
at the peak, and `-gap` should come down rather than up.

## If it touches timing

It does not change any constant. It is the instrument for deciding whether the
existing ones are right.

## Checklist

- [x] `gofmt -l ./cmd ./tools` prints nothing
- [x] `go vet ./...` and `go build ./...` are clean
- [x] No new dependency, standard library only
- [x] No token, transcript or student identifier in the diff
- [x] README or `docs/reference` updated if behaviour changed

Deliberately touches no existing file, to avoid conflicting with #7 and #8,
which are both editing `README.md` and `docs/reference/rate-limits.md`. Once
those merge, `rate-limits.md` should link to this and its headline claim should
be softened to what the evidence actually supports.
