### PR TITLE
Stop sleeping through the token a rejection frees

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ flowchart TD
     D --> E["send, then hold the next token for 1.3s"]
     E --> F{"result"}
     F -->|"OK or COURSE_DUPLICATE"| G["done, drop from the list"]
-    F -->|"429"| H["hold the shared token 2s,<br/>the course keeps its place"] --> A
+    F -->|"429"| H["never counted: retry at the<br/>boundary, the course keeps its place"] --> A
     F -->|"cannot succeed on a retry"| J["park it for 45s,<br/>behind everything else"] --> A
     F -->|"anything else"| I["cooldown 5.2s, retry"] --> A
 ```
@@ -175,7 +175,11 @@ the per course one, and below that the per course cooldown binds.
 The gap is 1.3 seconds rather than 1.1 because at 1.1s about one request in
 seven came back `429` on 2026-09-07, and at 1.3s none did. That is a small
 sample and a working default rather than a measured threshold, which is why
-`-gap` exists. The token is counted from the moment a request is written to
+`-gap` exists. The gap runs from the last request the edge **accepted**, not
+from the last one sent. A request it rejects is never counted and leaves that
+clock untouched, so a `429` costs a poll at the boundary rather than a fixed
+backoff, and the rejected request gives up its own claim on the clock and
+nobody else's. Acceptance is timed from the moment the request is written to
 the connection, not from when the scheduler decided to send it, because a
 request that has to open a connection first reaches the edge several hundred
 milliseconds later than one on a warm connection.

--- a/cmd/sniper/main.go
+++ b/cmd/sniper/main.go
@@ -435,6 +435,12 @@ func fireWindow(parent context.Context, ui *ui, cl *client, courses []*course) b
 		// like any other request, so start from whatever the edge last
 		// accepted rather than from now.
 		nextSend = cl.accepted().Add(globalGap)
+		// presumed is the send time of the newest request the edge has not
+		// rejected, and it is what nextSend is measured from. A 429 gives up
+		// that request's own claim on the clock and nobody else's: when the
+		// edge is slow to reject, which is what a contested window does, a
+		// later request has already left and is still presumed counted.
+		presumed = cl.accepted()
 		// rejectRun counts rejections since the last acceptance, so that a
 		// situation this model does not cover cannot become a hot loop.
 		rejectRun int
@@ -452,9 +458,12 @@ func fireWindow(parent context.Context, ui *ui, cl *client, courses []*course) b
 		mu.Lock()
 		// The client records when each request was actually written, which
 		// is later than the scheduler's send time on a cold connection, and
-		// the warm up writes a request the scheduler never sent at all.
-		// Only requests the edge accepted move this clock.
-		if ns := cl.accepted().Add(globalGap); ns.After(nextSend) {
+		// the warm up writes a request the scheduler never sent at all, so
+		// a confirmed acceptance can sit ahead of anything sent from here.
+		if a := cl.accepted(); a.After(presumed) {
+			presumed = a
+		}
+		if ns := presumed.Add(globalGap); ns.After(nextSend) {
 			nextSend = ns
 		}
 		finished, wait := allDone(courses), time.Until(nextSend)
@@ -463,9 +472,13 @@ func fireWindow(parent context.Context, ui *ui, cl *client, courses []*course) b
 			break
 		}
 		// Loop rather than fall through after sleeping: an answer arriving
-		// meanwhile can land the last course or push the token further out.
+		// meanwhile can land the last course, push the token further out, or
+		// bring it forward, which is why the sleep ends on one. A rejected
+		// request was never counted, so its retry falls due a poll later
+		// rather than a whole gap, and sleeping blind through the rejection
+		// gave that back as the fixed backoff it was meant to replace.
 		if wait > 0 {
-			if !sleepCtx(ctx, wait) {
+			if !sleepOrWake(ctx, wake, wait) {
 				break
 			}
 			continue
@@ -492,6 +505,7 @@ func fireWindow(parent context.Context, ui *ui, cl *client, courses []*course) b
 		pick.next = sent.Add(courseCooldown)
 		attempt := pick.attempts
 		nextSend = sent.Add(globalGap)
+		presumed = sent
 		inflight++
 		ui.tr.write("SCHED    send %s attempt %d, %d in flight, next token at %s",
 			pick.id, attempt, inflight, nextSend.Format("15:04:05.000"))
@@ -525,7 +539,12 @@ func fireWindow(parent context.Context, ui *ui, cl *client, courses []*course) b
 				c.next = sent
 				rejectRun++
 				poll := rejectRetry * time.Duration(1<<min(rejectRun-1, rejectRunCap))
-				nextSend = later(cl.accepted().Add(globalGap), time.Now().Add(poll))
+				if presumed.Equal(sent) {
+					// Nothing has left since the request the edge threw
+					// away, so its claim is the only one to give up.
+					presumed = cl.accepted()
+				}
+				nextSend = later(presumed.Add(globalGap), time.Now().Add(poll))
 				ui.attempt(c, attempt, "429 RATE LIMITED",
 					fmt.Sprintf("edge rejected it, it was never counted, retrying at %s",
 						nextSend.Format("15:04:05.000")), rtt, kindWarn)
@@ -632,13 +651,21 @@ func waitForWake(ctx context.Context, wake <-chan struct{}, earliest time.Time) 
 		}
 		return
 	}
-	t := time.NewTimer(time.Until(earliest))
+	sleepOrWake(ctx, wake, time.Until(earliest))
+}
+
+// sleepOrWake waits out d, or until an answer lands, whichever comes first,
+// and reports whether the run is still going.
+func sleepOrWake(ctx context.Context, wake <-chan struct{}, d time.Duration) bool {
+	t := time.NewTimer(d)
 	defer t.Stop()
 	select {
 	case <-t.C:
 	case <-wake:
 	case <-ctx.Done():
+		return false
 	}
+	return true
 }
 
 // later is the more distant of two instants.

--- a/cmd/sniper/sniper_test.go
+++ b/cmd/sniper/sniper_test.go
@@ -559,3 +559,177 @@ func TestFireWindowRetriesSoonAfterARejection(t *testing.T) {
 		}
 	}
 }
+
+// TestFireWindowKeepsFiringWhileAnswersTimeOut reproduces the window a friend
+// caught on camera: the portal answered nothing inside the client timeout, so
+// almost every request died at 10s. The released v1.0.x scheduler sent inline
+// and picked under strict priority, so each timeout froze the whole run for
+// the full timeout and the first course on the list was eligible again the
+// moment it unfroze. One course absorbed nine attempts across eighty seconds
+// while five courses never got a single request. Sending has to carry on
+// while answers are outstanding.
+func TestFireWindowKeepsFiringWhileAnswersTimeOut(t *testing.T) {
+	const (
+		gap     = 60 * time.Millisecond
+		timeout = 400 * time.Millisecond
+	)
+	var (
+		mu      sync.Mutex
+		arrived []string
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body regRequest
+		json.NewDecoder(r.Body).Decode(&body)
+		mu.Lock()
+		arrived = append(arrived, body.Course)
+		mu.Unlock()
+		<-r.Context().Done() // never answer, exactly as the live window did
+	}))
+	defer srv.Close()
+
+	defer swap(&regEndpoint, srv.URL)()
+	defer swap(&globalGap, gap)()
+	defer swap(&maxInflight, 0)()
+
+	courses := mkCourses("a", "b", "c", "d", "e", "f")
+	cl := &client{http: &http.Client{Timeout: timeout}}
+	// One timeout's worth of window. Under the old scheduler that bought one
+	// request; six courses one gap apart all fit inside it.
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	fireWindow(ctx, newTestUI(), cl, courses)
+
+	mu.Lock()
+	defer mu.Unlock()
+	for _, c := range courses {
+		if c.attempts == 0 {
+			t.Errorf("%s never got a request while the others sat waiting on answers", c.id)
+		}
+	}
+	if len(arrived) < len(courses) {
+		t.Errorf("the portal saw %d requests in one timeout, want at least %d", len(arrived), len(courses))
+	}
+}
+
+// TestRejectionOnlyGivesUpItsOwnClaimOnTheClock guards the other half of
+// pacing from the last accepted request. A 429 rolls back the optimistic claim
+// the rejected request made on the clock, and nothing else's. When the edge is
+// slow to reject, which is exactly what a contested window does, another
+// request has already left by the time the rejection lands, and that one is
+// still presumed counted. Rolling the clock all the way back to the last
+// confirmed acceptance fires the next request inside the gap and buys a
+// second rejection.
+func TestRejectionOnlyGivesUpItsOwnClaimOnTheClock(t *testing.T) {
+	const gap = 600 * time.Millisecond
+
+	var (
+		mu       sync.Mutex
+		arrivals []time.Time
+		n        int
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body regRequest
+		json.NewDecoder(r.Body).Decode(&body)
+		mu.Lock()
+		arrivals = append(arrivals, time.Now())
+		n++
+		which := n
+		mu.Unlock()
+
+		switch which {
+		case 1:
+			// Rejected, but slowly, so the next request leaves first.
+			time.Sleep(gap + 100*time.Millisecond)
+			w.WriteHeader(http.StatusTooManyRequests)
+			fmt.Fprint(w, "<html>429</html>")
+		case 2:
+			// Accepted, and still outstanding when the rejection lands, so
+			// the scheduler has only its own send time to go on.
+			time.Sleep(3 * gap)
+			json.NewEncoder(w).Encode(regResponse{Time: time.Now().UnixMilli()})
+		default:
+			json.NewEncoder(w).Encode(regResponse{Time: time.Now().UnixMilli()})
+		}
+	}))
+	defer srv.Close()
+
+	defer swap(&regEndpoint, srv.URL)()
+	defer swap(&globalGap, gap)()
+	defer swap(&maxInflight, 0)()
+
+	cl := &client{http: &http.Client{Timeout: 5 * time.Second}}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*gap)
+	defer cancel()
+
+	fireWindow(ctx, newTestUI(), cl, mkCourses("a", "b"))
+
+	mu.Lock()
+	defer mu.Unlock()
+	for i, a := range arrivals {
+		t.Logf("arrival %d at +%s", i+1, a.Sub(arrivals[0]).Truncate(time.Millisecond))
+	}
+	if len(arrivals) < 3 {
+		t.Fatalf("got %d requests, want at least 3", len(arrivals))
+	}
+	// The second request was never rejected, so it still holds the clock.
+	// The third is due a gap after it, not a poll after the first request's
+	// rejection.
+	if since := arrivals[2].Sub(arrivals[1]); since < gap-100*time.Millisecond {
+		t.Errorf("third request went out %s after the second, want about %s: the rejection rolled back a claim that was not its own", since, gap)
+	}
+}
+
+// TestFireWindowDoesNotSleepThroughAFastRetry is the other half of pacing from
+// the last accepted request. The scheduler sleeps toward the token it reserved
+// when it sent, and an answer landing meanwhile can bring that token forward:
+// a 429 was never counted, so the next request is due a poll later rather than
+// a whole gap. Sleeping blind through the rejection throws that away and hands
+// back the fixed backoff the measurement was meant to remove.
+func TestFireWindowDoesNotSleepThroughAFastRetry(t *testing.T) {
+	const gap = 800 * time.Millisecond
+
+	var (
+		mu       sync.Mutex
+		arrivals []time.Time
+		n        int
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		arrivals = append(arrivals, time.Now())
+		n++
+		first := n == 1
+		mu.Unlock()
+
+		if first {
+			w.WriteHeader(http.StatusTooManyRequests)
+			fmt.Fprint(w, "<html>429</html>")
+			return
+		}
+		json.NewEncoder(w).Encode(regResponse{
+			Jobs: []job{{CourseID: "a", Result: resultOK}}, Time: time.Now().UnixMilli(),
+		})
+	}))
+	defer srv.Close()
+
+	defer swap(&regEndpoint, srv.URL)()
+	defer swap(&globalGap, gap)()
+	defer swap(&maxInflight, 0)()
+
+	cl := &client{http: &http.Client{Timeout: 2 * time.Second}}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*gap)
+	defer cancel()
+
+	fireWindow(ctx, newTestUI(), cl, mkCourses("a"))
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(arrivals) < 2 {
+		t.Fatalf("got %d requests, want the rejected one and its retry", len(arrivals))
+	}
+	// Nothing had been accepted, so the retry is due as soon as the poll
+	// delay is up, nowhere near a full gap later.
+	if since := arrivals[1].Sub(arrivals[0]); since > gap/2 {
+		t.Errorf("retried %s after the rejection, want about %s: the scheduler slept through it", since, rejectRetry)
+	}
+}

--- a/docs/reference/rate-limits.md
+++ b/docs/reference/rate-limits.md
@@ -54,9 +54,11 @@ Run B also took a second `429` at 08:00:35, a full 5 seconds after its previous
 request and in the same millisecond as the answer to it. Nothing the sniper
 sent explains that, and it is the one observation no per client model covers. The limiter is keyed on the IP, so the traffic came from
 alongside it: a click in the browser, or another student behind the same NAT.
-The scheduler now treats a `429` as a 2 second hold on the shared token with
-the course keeping its place, which is the right response either way, but a
-browser tab on the portal during the window is a cost you can avoid.
+The scheduler now treats a `429` as evidence that the rejected request was
+never counted: the course keeps its place, and the next request is due a token
+after whatever the edge last accepted rather than a fixed wait after the
+rejection. That is the right response either way, but a browser tab on the
+portal during the window is a cost you can avoid.
 
 Both runs also got `REPEATED_REQUEST` on a course that then landed from a job
 the sniper had not knowingly queued. The job ids sit where a request sent a


### PR DESCRIPTION
## What this changes

Two defects in the pacing that landed in 7de44c3, plus the regression test for the condition that exposed them.

1. **The fast retry after a 429 never fired.** The scheduler slept toward the token it reserved when it sent, and only the "nothing eligible" branch drained the wake channel, so an answer that brought the deadline forward could not shorten the sleep. It printed `retrying at 47.267` and retried at `47.868`. The pacing sleep now ends on an answer.
2. **The rollback gave up claims that were not its own.** `nextSend` was assigned from the last *confirmed* acceptance, discarding the claim of any request sent after the rejected one. The scheduler now tracks the send time of the newest request the edge has not rejected, and a 429 gives up that request's claim and nobody else's.

## Why

A friend's window on the released v1.0.2 binary came back with nine attempts on one course and none at all on the other five. Every failure in that run is already closed on main (34c8c7f, 8eb1b01, df54a9c, 7de44c3), but it showed one condition nothing here has ever been tested against: a portal that answers nothing inside the client timeout. Writing that test turned up both defects above.

## How it was verified

Against stand-in portals, not a live window. Each new test was confirmed to fail without its own fix by reverting that fix alone:

- `TestFireWindowDoesNotSleepThroughAFastRetry`: retried 800ms after the rejection at an 800ms gap, against the 200ms it announced.
- `TestRejectionOnlyGivesUpItsOwnClaimOnTheClock`: with only the wake fix in place, the third request went out 302ms behind one that had left 600ms earlier, into a 600ms gap.
- `TestFireWindowKeepsFiringWhileAnswersTimeOut`: six courses all get a request inside a single client timeout while every answer is outstanding. The v1.0.x scheduler bought exactly one request in that span.

`go test -race ./... -count=3` clean.

## If it touches timing

No measured constant changed. `globalGap`, `courseCooldown`, `rejectRetry` and `rejectRunCap` are all untouched. What changed is that the pacing now behaves the way 7de44c3 documented: the gap is measured from the last request the edge accepted, and a rejection is polled at the boundary rather than waited out.

## Checklist

- [x] `gofmt -l ./cmd ./tools` prints nothing
- [x] `go vet ./...` and `go build ./...` are clean
- [x] No new dependency, and `cmd/sniper` is still standard library only
- [x] No token, transcript or student identifier in the diff
- [x] README or `docs/reference` updated if behaviour changed